### PR TITLE
17136 색종이 붙이기 PR

### DIFF
--- a/김지현/0801/boj_17136_색종이붙이기.java
+++ b/김지현/0801/boj_17136_색종이붙이기.java
@@ -1,0 +1,82 @@
+import java.util.*;
+import java.io.*;
+
+// 23428KB	264ms
+public class boj_17136_색종이붙이기 {
+    static int[][] paper = new int[10][10];
+    static int[] remain = {0, 5, 5, 5, 5, 5}; // 남은 종이 수
+    static int res = Integer.MAX_VALUE;
+
+    public static void main(String[] args) throws Exception {
+//        System.setIn(new FileInputStream("res/input_boj_17136.txt"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        for (int i = 0; i < 10; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 10; j++) {
+                paper[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        dfs(0, 0, 0);
+
+        if (res == Integer.MAX_VALUE) res = -1;
+
+        System.out.println(res);
+        br.close();
+
+    }
+
+    // dfs + 백트래킹
+    public static void dfs(int x, int y, int cnt) {
+        // 종료 조건 : 맨 끝 도착
+        if (x >= 9 && y > 9) {
+            res = Math.min(res, cnt);
+            return;
+        }
+
+        // 기존에 구해놓은 res보다, cnt가 커지면, 종료
+        if (res <= cnt) return;
+
+        // 마지막 열 넘으면, 다음 줄로 가기.
+        if (y > 9) {
+            dfs(x + 1, 0, cnt);
+            return;
+        }
+
+        if (paper[x][y] == 1) {
+            for (int i = 5; i >= 1; i--) { // 색종이 큰 것부터 붙이기
+                if (remain[i] > 0 && isAttach(x, y, i)) {
+                    attach(x, y, i, 0); // 붙임
+                    remain[i]--; // 색종이 붙였으니, 남은 개수 하나 빼기
+                    dfs(x, y + 1, cnt + 1);
+                    attach(x, y, i, 1); // 다시 뗌
+                    remain[i]++; // 색종이 떼어낸 거, 남은 개수 더해주기
+                }
+            }
+        } else { // paper[x][y] == 0 인 경우 오른쪽으로 이동
+            dfs(x, y + 1, cnt);
+        }
+    }
+
+    // 색종이 붙이고 떼는 것 한 번에 구현(0:붙이기, 1:떼기)
+    public static void attach(int x, int y, int size, int state) {
+        for (int i = x; i < x + size; i++) {
+            for (int j = y; j < y + size; j++) {
+                paper[i][j] = state;
+            }
+        }
+    }
+
+    // 색종이 크기만큼 모두 1인지 확인
+    public static boolean isAttach(int x, int y, int size) {
+        for (int i = x; i < x + size; i++) {
+            for (int j = y; j < y + size; j++) {
+                if (i < 0 || i >= 10 || j < 0 || j >= 10) return false;
+                if (paper[i][j] != 1) return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## BOJ 17136 색종이 붙이기
23428KB	 264ms

### 문제 풀이
- `dfs + 백트래킹`의 조합으로 완전탐색으로 풀 수 있다.
- 처음에, 큰 종이부터 넣는 그리디를 생각했으나, 큰 거 하나를 넣는 것보다, 작은 종이 여러 개를 넣는게 최소의 횟수가 나오는 것을 보고, 완전 탐색이라 생각했다.
- 색종이의 남은 개수는 remain 배열로 관리

### 주의
- 백트래킹 종료조건이 `x = 9, y = 10` 일 때! 이다. 