### PR TITLE
김준엽 - 야구공, 배열돌리기4

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/Algorithm.iml
+++ b/.idea/Algorithm.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Algorithm.iml" filepath="$PROJECT_DIR$/.idea/Algorithm.iml" />
+      <module fileurl="file://$PROJECT_DIR$/김준엽/김준엽.iml" filepath="$PROJECT_DIR$/김준엽/김준엽.iml" />
+      <module fileurl="file://$PROJECT_DIR$/김지현/김지현.iml" filepath="$PROJECT_DIR$/김지현/김지현.iml" />
+      <module fileurl="file://$PROJECT_DIR$/남수진/남수진.iml" filepath="$PROJECT_DIR$/남수진/남수진.iml" />
+      <module fileurl="file://$PROJECT_DIR$/전소영/전소영.iml" filepath="$PROJECT_DIR$/전소영/전소영.iml" />
+      <module fileurl="file://$PROJECT_DIR$/한태희/한태희.iml" filepath="$PROJECT_DIR$/한태희/한태희.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/김준엽/20230808/boj_17281_야구공.java
+++ b/김준엽/20230808/boj_17281_야구공.java
@@ -1,49 +1,123 @@
-package study;
 
 import java.util.*;
 import java.io.*;
-public class Main_17281 {
-	static int N;
-	static int [][] sunsu;
-	static int []likeSunsu;
-	static int [] dummy = new int[8];
-	static int prevHitter = 0;
-	public static void main(String[] args) throws Exception{
-		System.setIn(new FileInputStream("study/input.txt"));
-		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-		StringTokenizer st = new StringTokenizer(br.readLine());
+public class Main {
+    static int N;
+    static int [][] sunsu;
+    static int[] lineUp;
+    static boolean [] visited;
+    static int ans;
+    public static void main(String[] args) throws Exception{
+        System.setIn(new FileInputStream("study/input.txt"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
 
-		N = Integer.parseInt(st.nextToken());
-		likeSunsu = new int[N];
-		sunsu = new int [N][8];
-		//입력
-		for(int i=0; i<N; i++) {
-			st = new StringTokenizer(br.readLine());
-			likeSunsu[i] = Integer.parseInt(st.nextToken());
-			for(int j=0; j<8; j++) sunsu[i][j] = Integer.parseInt(st.nextToken());
-		}
-		
-		for(int i =0; i<N; i++) {
-			comb(0,0,i);
-		}
-		
-		
-	}
-	static void comb(int depth , int start, int inning) {
-		if(depth == 8) {
-			System.out.println(Arrays.toString(dummy));
-			return;
-		}
-		for(int i=start; i<8; i++) {
-			dummy[depth] = sunsu[inning][i];
-			comb(depth+1, start+1, inning);
-		}
-	}
-	static void simulation() {
-		//prevHitter부터 시작 + 9번타자 이후에 %를 이용하여 0번 타자로 시작하는 무한반복문
-		int outCount = 0;
-		int score = 0;
-		
-	}
-	
+        N = Integer.parseInt(st.nextToken());
+        sunsu = new int [N+1][10];
+        //입력
+        for(int i=1; i<=N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= 9; j++) {
+                sunsu[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        visited = new boolean[10];
+        lineUp = new int[10];
+
+        visited[4] = true;
+        lineUp[4] = 1;
+
+        ans = 0;
+        comb(2);
+        System.out.println(ans);
+
+    }
+    static void comb(int depth) {
+        if(depth == 10) {
+            simulation();
+            return;
+        }
+        for(int i=1; i<=9; i++) {
+            if(visited[i]) continue;
+            visited[i] = true;
+            lineUp[i] = depth;
+            comb(depth+1);
+            visited[i] = false;
+        }
+    }
+    static void simulation() {
+        int score = 0;
+        int startPlayer = 1;
+        boolean[] base;
+
+        for (int i = 1; i <= N; i++) {
+            int out = 0;
+            base = new boolean[4];
+            flag:while (true) {
+                for (int j = startPlayer; j <= 9; j++) {
+                    int hitter = sunsu[i][lineUp[j]];
+                    switch (hitter) {
+                        case 0:
+                            out++;
+                            break;
+                        case 1:
+                            for (int k = 3; k >= 1; k--) {
+                                if (base[k]) {
+                                    if (k == 3) {
+                                        score++;
+                                        base[k] = false;
+                                        continue;
+                                    }
+                                    base[k] = false;
+                                    base[k + 1] = true;
+                                }
+                            }
+                            base[1] = true;
+                            break;
+                        case 2:
+                            for (int k = 3; k >= 1; k--) {
+                                if (base[k]) {
+                                    if (k == 3 || k == 2) {
+                                        score++;
+                                        base[k] = false;
+                                        continue;
+                                    }
+                                    base[k] = false;
+                                    base[k + 2] = true;
+                                }
+                            }
+                                base[2] = true;
+                                break;
+                        case 3:
+                            for (int k = 3; k >= 1; k--) {
+                                if (base[k]) {
+                                    score++;
+                                    base[k] = false;
+                                }
+                            }
+                            base[3] = true; // 홈에서 3루로 진루.
+                            break;
+                        case 4:
+                            for (int k = 1; k <= 3; k++) {
+                                if (base[k]) {
+                                    score++;
+                                    base[k] = false;
+                                }
+                            }
+                            score++;
+                            break;
+                    }
+                    if (out == 3) {
+                        startPlayer = j + 1;
+                        if (startPlayer == 10) {
+                            startPlayer = 1;
+                        }
+                        break flag;
+                    }
+                }
+                startPlayer = 1;
+            }
+        }
+        ans = Math.max(ans,score);
+    }
 }

--- a/김준엽/20230808/boj_17281_야구공.java
+++ b/김준엽/20230808/boj_17281_야구공.java
@@ -1,0 +1,12 @@
+package study;
+
+import java.util.*;
+import java.io.*;
+public class Main_17281 {
+	public static void main(String[] args) throws Exception{
+		System.setIn(new FileInputStream("study/input.txt"));
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+	}
+
+}

--- a/김준엽/20230808/boj_17281_야구공.java
+++ b/김준엽/20230808/boj_17281_야구공.java
@@ -3,10 +3,47 @@ package study;
 import java.util.*;
 import java.io.*;
 public class Main_17281 {
+	static int N;
+	static int [][] sunsu;
+	static int []likeSunsu;
+	static int [] dummy = new int[8];
+	static int prevHitter = 0;
 	public static void main(String[] args) throws Exception{
 		System.setIn(new FileInputStream("study/input.txt"));
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		N = Integer.parseInt(st.nextToken());
+		likeSunsu = new int[N];
+		sunsu = new int [N][8];
+		//입력
+		for(int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			likeSunsu[i] = Integer.parseInt(st.nextToken());
+			for(int j=0; j<8; j++) sunsu[i][j] = Integer.parseInt(st.nextToken());
+		}
+		
+		for(int i =0; i<N; i++) {
+			comb(0,0,i);
+		}
+		
 		
 	}
-
+	static void comb(int depth , int start, int inning) {
+		if(depth == 8) {
+			System.out.println(Arrays.toString(dummy));
+			return;
+		}
+		for(int i=start; i<8; i++) {
+			dummy[depth] = sunsu[inning][i];
+			comb(depth+1, start+1, inning);
+		}
+	}
+	static void simulation() {
+		//prevHitter부터 시작 + 9번타자 이후에 %를 이용하여 0번 타자로 시작하는 무한반복문
+		int outCount = 0;
+		int score = 0;
+		
+	}
+	
 }

--- a/김준엽/20230808/boj_17406_배열돌리기.java
+++ b/김준엽/20230808/boj_17406_배열돌리기.java
@@ -1,0 +1,106 @@
+package study;
+
+import java.io.*;
+import java.util.*;
+
+public class 배열돌리기4 {
+	static int [][] board;
+	static int [][] copyBoard;
+	static int [][] rotate;
+	static boolean [] check;
+	static int [] index;
+	static int N,M,K;
+	static int answer = Integer.MAX_VALUE;
+	public static void main(String[] args) throws Exception {
+		System.setIn(new FileInputStream("res/input_17406.txt"));
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		StringBuilder sb = new StringBuilder();
+		N = Integer.parseInt(st.nextToken()); 
+		M = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		board = new int[N][M];
+		copyBoard = new int[N][M];
+		rotate = new int[K][3];
+		check = new boolean[K];
+		index = new int[K];
+		for(int i = 0 ; i<N ; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j=0; j<M; j ++) {
+				board[i][j] = Integer.parseInt(st.nextToken());
+				copyBoard[i][j] = board[i][j];
+			}
+		}		
+		for(int i=0; i<K; i++) {
+			st = new StringTokenizer(br.readLine());
+			rotate[i][0] = Integer.parseInt(st.nextToken());
+			rotate[i][1] = Integer.parseInt(st.nextToken());
+			rotate[i][2] = Integer.parseInt(st.nextToken());
+//			int x1 = r-s-1, y1 = c-s-1, x2 = r+s-1, y2 = c+s-1;
+//			while(x1 != x2 && y1 != y2) {
+//				System.out.println(x1 + ", " + x2 + ", " + y1 + ", " +y2);
+//				rotation(x1++,y1++,x2--,y2--);
+//			}
+		}
+		permutation(0);
+//		for(int i = 0; i<N; i++) System.out.println(Arrays.toString(board[i]));
+//		rotation(0,0,0,0);
+//		System.out.println();
+//		for(int i = 0; i<N; i++) System.out.println(Arrays.toString(board[i]));
+		System.out.println(answer);
+	}
+	static void permutation(int depth) {
+		if(depth == K) {
+			for(int i=0; i<K; i++) {
+				int r = rotate[index[i]][0];
+				int c = rotate[index[i]][1];
+				int s = rotate[index[i]][2];
+				int x1 = r-s-1, y1 = c-s-1, x2 = r+s-1, y2 = c+s-1;
+				while(x1 != x2 && y1 != y2) {
+					rotation(x1++,y1++,x2--,y2--);
+				}
+			}
+			//한 케이스에 대하여 회전 끝
+			findMin();
+			init();
+//			System.out.println(answer);
+			return;
+		}
+		for(int i=0; i<K; i++) {
+			if(check[i]) continue;
+			check[i] = true;
+			index[depth] = i;
+			permutation(depth+1);
+			check[i] = false;
+		}
+		
+	}
+	static void rotation(int x1, int y1,int x2, int y2) {
+		int tmp = board[x1][y1];
+		//left
+		for(int i=x1+1; i<=x2; i++) board[i-1][y1] =board[i][y1];
+		//down
+		for(int i=y1+1; i<=y2; i++) board[x2][i-1] = board[x2][i];
+		//right
+		for(int i=x2-1; i>=x1; i--) board[i+1][y2] = board[i][y2];
+		//top
+		for(int i = y2-1; i>y1; i--) board[x1][i+1] = board[x1][i];
+		board[x1][y1+1] = tmp;
+	}
+	static void findMin() {
+		for(int i=0; i<N; i++) {
+			int tmp = 0;
+			for(int j=0; j<M; j++) {
+				tmp += board[i][j];
+			}
+			if(tmp < answer) answer = tmp;
+		}
+	}
+	static void init() {
+		for(int i=0; i<N; i++) {
+			for(int j=0; j<M; j++) {
+				board[i][j] = copyBoard[i][j];
+			}
+		}
+	}
+}

--- a/김준엽/김준엽.iml
+++ b/김준엽/김준엽.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/20230725" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/20230801" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/김지현/김지현.iml
+++ b/김지현/김지현.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/0725" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/남수진/남수진.iml
+++ b/남수진/남수진.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/0725" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/전소영/전소영.iml
+++ b/전소영/전소영.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/2307-4주차" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/한태희/한태희.iml
+++ b/한태희/한태희.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/Backjoon_16637_괄호_추가하기" isTestSource="false" packagePrefix="algostudy" />
+      <sourceFolder url="file://$MODULE_DIR$/Backjoon_17070_파이프_옮기기" isTestSource="false" packagePrefix="algostudy" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
# 야구공
시뮬레이션 부분을 외부 코드를 참조하느라 거의 외부코드에 맞춰져 있지만, 이전에 구체적인 구현까지는 했었습니다. 마지막에 아웃이랑 진출한 타자를 체킹하는 과정에서 너무 시간을 써서 결국 인터넷 코드를 참조했습니다.
1. 타자 순서를 정하는 배열의 인덱스를 우선 comb 함수를 통해 생성합니다. ( 8! )
2. 타자의 순서는 한번 정해지면 바꿀 수 없으므로 이닝 당 타자의 인덱스로 시뮬레이션을 진행합니다.
3. 이닝당 3 out이 될 때까지 계속 게임을 진행합니다.
4. 3아웃이 되어도 이전의 타자 순서는 기억하여 다음 타자로 이닝을 진행합니다.

# 배열돌리기4
우선 배열을 돌리는 경우의 수를 permutation을 이용하여 모든 경우의 수를 구합니다. K가 최대 6이기 때문에 6!
그리고 배열의 회전을 각 범위에 맞추어 왼쪽 상단, 우측 하단을 기준으로 외곽을 한번 회전하고, 왼쪽 상단은 우측 대각 아래로 좌표를 이동시키고, 우측 하단의 좌표는 좌측 대각 위로 좌표를 이동시키며 외곽을 좁혀나가며 배열을 회전 시키고, 두 좌표가 만날때까지 계속 하여 반복합니다.
