### PR TITLE
한태희 0912

### DIFF
--- a/한태희/0912/Main_bj_g2_1949_우수_마을.java
+++ b/한태희/0912/Main_bj_g2_1949_우수_마을.java
@@ -1,0 +1,118 @@
+import java.util.*;
+import java.io.*;
+
+/**
+ * 인터넷에서 아이디어를 참고했습니다.
+ * 
+ * 만약 부분집합을 사용하며, 조건에 만족하지 않는 케이스를 중간에 프루닝 하더라도, 경우의 수가 1억이 넘어가기 때문에 제한 시간 안에
+ * 실행이 불가능하다.
+ * 필연적으로 이 문제는 다이나믹 프로그래밍, 이분탐색, 그래프 이론 중 하나를 사용해야 함을 알 수 있다.
+ * 
+ * 이 문제는 다이나믹 프로그래밍을 사용해서 풀 수 있다.
+ * 이 문제의 첫번째 난관은 마을들이 트리 구조로 연결 되어 있으면서, 막상 루트 노드를 특정해주지는 않는다는 것이다.
+ * 이것을 해결하기 위해선 트리의 속성에 대한 지식이 필요한데, 임의의 노드를 루트 노드로 선정하면 그 루트 노드를 기준으로 트리가 구성
+ * 가능하다.
+ * 
+ * 트리가 계층으로 구성되었으면, 임의의 노드 N이 있다고 하고, 해당 노드의 자식들을 c1, c2, ... ck 라고 할때, 다음과 같은
+ * 재귀 식을 세울 수 있다.
+ * 노드 N의 인구 population(N)
+ * 노드 N을 우수 마을로 선정 했을 때, 해당 노드를 루트로 하는 서브 트리의 우수마을 인구의 합 choice(N)
+ * 노드 N을 우수 마을로 선정하지 않았을 때, 해당 노드를 루트로 하는 서브 트리의 우수마을 인구의 합 abandon(N)
+ * choice(N) = population(N) + abandon(c1) + abandon(c2) + ... + abandon(ck)
+ * abandon(N) = Max( choice(c1), abandon(c1) ) + Max( choice(c2), abandon(c2) )
+ * + ... + Max( choice(ck), abandon(ck) )
+ * 
+ * 헤맸던 부분
+ * 3번 조건. 선정되지 못한 마을에 경각심을 불러일으키기 위해서, '우수 마을'로 선정되지 못한 마을은 적어도 하나의 '우수 마을'과는
+ * 인접해 있어야 한다.
+ * 이 부분을 고민하느라고 문제를 풀지 못했습니다.
+ * 인터넷을 보니, 이 부분은 최대값을 구하는 과정에서 자연스럽게 만족된다는 것을 알게 되었습니다.
+ * 
+ * 생각해보면 다음과 같습니다.
+ * 만약 마을 A-B-C-D-E가 있다면 X-B-X-X-E로 선택된 경우가 A-X-C-X-E로 선택된 경우보다 더 클때,
+ * abandon(A)는 자연스럽게 X-B-X-X-E로 업데이트 되게 되고, abandon(A)가 choice(A)보다 크게 됨으로 자연스럽게
+ * 해답을 구할 수 있습니다.
+ * A-X-X-X-E 는 무조건 A-X-C-X-E보다 작게 됨으로, 선택되지 않는 마을이 우수 마을과 인접하지 않는 경우는 무조건 최대값이
+ * 아닙니다.
+ */
+public class Main_bj_g2_1949_우수_마을 {
+	static int N;
+	static int[] pop;
+	static List[] next;
+
+	public static void main(String args[]) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		// 마을의 개수 N
+		N = Integer.parseInt(br.readLine());
+		// 임의의 마을 E의 인구 Pouplation(E)
+		pop = new int[N + 1];
+		// 임의의 마을 E와 연결된 마을들 next(E)
+		next = new List[N + 1];
+
+		// 배열 초기화 및 인구 입력
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for (int i = 1; i <= N; i++) {
+			pop[i] = (Integer.parseInt(st.nextToken()));
+			next[i] = new ArrayList<>();
+		}
+
+		// 주어진 연결을 입력함
+		for (int i = 0; i < N - 1; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			next[a].add(b);
+			next[b].add(a);
+		}
+
+		// 임의로 루트 노드를 정한다.
+		int v = -1;
+		for (int i = 1; i <= N; i++) {
+			if (next[i].size() == 1) {
+				v = i;
+				break;
+			}
+		}
+
+		// 임의의 루트 노드를 기준으로 재귀 탐색을 진행하고, choice(v) 와 abandon(v) 중 더 큰 것을 출력한다.
+		int max = -1;
+		for (int k : search(v)) {
+			max = Math.max(max, k);
+		}
+		System.out.println(max);
+
+		br.close();
+	}
+
+	/**
+	 * 임의의 노드 v에 대하여, {choice(v), abandon(v)} 를 반환
+	 */
+	static int[] search(int v) {
+		List<Integer> childs = next[v];
+
+		List<int[]> res = new ArrayList<>();
+		for (int c : childs) {
+			// 자식 c의 {choice(c), abandon(c)}를 구해서 res List에 더한다.
+			next[c].remove(Integer.valueOf(v));
+			res.add(search(c));
+		}
+
+		// 선택을 하는 경우
+		// choice(N) = population(N) + abandon(c1) + abandon(c2) + ... + abandon(ck)
+		int choice = pop[v];
+		for (int[] l : res) {
+			choice += l[1];
+		}
+
+		// 선택을 안하는 경우
+		// abandon(N) = Max( choice(c1), abandon(c1) ) + Max( choice(c2), abandon(c2) )
+		// + ... + Max( choice(ck), abandon(ck) )
+		int abandon = 0;
+		for (int[] l : res) {
+			abandon += Math.max(l[0], l[1]);
+		}
+		return new int[] { choice, abandon };
+	}
+
+}

--- a/한태희/0912/Main_bj_g3_양_구출_작전.java
+++ b/한태희/0912/Main_bj_g3_양_구출_작전.java
@@ -1,0 +1,107 @@
+import java.util.*;
+import java.io.*;
+
+public class Main_bj_g3_양_구출_작전 {
+
+	static class Node {
+		int snum; // sheep_num;
+		int wnum; // wolf_num;
+		int parrent; // parent_idx;
+
+		Node(int sn, int wn, int p) {
+			int snum = sn;
+			int wnum = wn;
+			parrent = p;
+		}
+
+		int getDepth(Node[] arr) {
+			if (parrent == -1)
+				return 0;
+			else
+				return arr[parrent].getDepth(arr) + 1;
+		}
+
+		@Override
+		public String toString() {
+			return "Node [snum=" + snum + ", wnum=" + wnum + ", parrent=" + parrent + "]";
+		}
+
+	}
+
+	public static void main(String args[]) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int N = Integer.parseInt(br.readLine());
+		Node[] arr = new Node[N + 1];
+		boolean[] hca = new boolean[N + 1]; // has_child_arr
+
+		arr[1] = new Node(0, 0, -1);
+
+		for (int i = 2; i <= N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			char t = st.nextToken().charAt(0);
+			int a = Integer.parseInt(st.nextToken());
+			int p = Integer.parseInt(st.nextToken());
+
+			if (t == 'S') {
+				arr[i] = new Node(a, 0, p);
+			} else { // t=='W'
+				arr[i] = new Node(0, a, p);
+			}
+
+			hca[p] = true;
+		}
+
+		// pq에 저장되는 배열
+		// [depth, before, next]
+		PriorityQueue<int[]> pq = new PriorityQueue<>(
+				(o1, o2) -> -Integer.compare(o1[0], o2[0]));
+
+		// leaf Node일 경우 다음 노드를 queue에 탐색 등록
+		for (int i = 2; i <= N; i++) {
+			if (hca[i] == false) {
+				pq.offer(new int[] { arr[i].getDepth(arr) - 1, i, arr[i].parrent });
+			}
+		}
+
+		// for (int[] t : pq) {
+		// System.out.println(Arrays.toString(t));
+		// }
+
+		int ans;
+		while (true) {
+			for (int[] t : pq) {
+				System.out.println(Arrays.toString(t));
+			}
+			System.out.println();
+			int[] info = pq.poll();
+			int depth = info[0];
+			int before = info[1];
+			int next = info[2];
+
+			// 다음 노드가 없을 경우 ans를 업데이트하고 종료
+			if (next == -1) {
+				ans = arr[next].snum;
+				break;
+			}
+			// 다음 노드가 있을 경우,
+			// 만약 늑대가 다음 노드에 있는 경우 늑대가 양을 잡아먹고
+			// 살아남은 양들이 다음 노드로 이동.
+			else {
+				// 늑대가 양을 잡아먹는다:
+				// 만약 다음 섬의 늑대의 수가 더 많거나 같으면 양은 모두 죽고
+				// 죽은 양 수만큼 배고픈 늑대가 사라진다.
+				if (arr[next].wnum >= info[2]) {
+
+				}
+				// 만약 다음 섬의 양의 수가 더 많으면 배고픈 늑대는 모두 사라지고
+				// 사라진 늑대만큼 양이 죽는다.
+			}
+		}
+
+		System.out.println(ans);
+
+		br.close();
+	}
+
+}

--- a/한태희/0912/Main_bj_g3_양_구출_작전.java
+++ b/한태희/0912/Main_bj_g3_양_구출_작전.java
@@ -1,29 +1,44 @@
 import java.util.*;
 import java.io.*;
 
+/**
+ * 재귀적으로 생각하면, 섬 I와 해당 섬의 자식 섬 c1, c2,... ck가 있을 때,
+ * 
+ * 자식 섬들에서 생존한 양들의 합이 섬 I의 늑대의 수보다 많은 경우:
+ * 양은 늑대의 수만큼 잡아먹히고, 섬 I의 늑대가 모두 사라진 후, 남은 양들이 섬 I로 건너온다.
+ * 
+ * 자식 섬들에서 생존한 양들의 합이 섬 I의 늑대의 수보다 적은 경우:
+ * 모든 자식 섬의 양들은 잡아먹히고, 잡아먹힌 양의 수만큼 늑대가 사라진다.
+ * 
+ * 다음과 같이 생각할 수 있다.
+ * 
+ * 문제는, 섬의 개수가 10만개가 넘어서 이것을 재귀함수로 구현할 경우, StackOverFlowError가 발생할 것이라는 것이다.
+ * 최악으로 10만개의 섬이 일렬로 연결 되어 있으면 재귀적으로 실행 불가능하다.
+ * 
+ * 결국 BottomUp적인 방식으로 구현할 수 밖에 없는데, 이를 위해서 큐를 사용한다.
+ * 큐에는 자식이 없는 섬들만 항상 들어간다. 만약 임의의 섬의 탐색이 완료되면 해당 섬의 부모와의 연결을
+ * 끊는 방식으로 자식이 없는 섬들을 늘려나간다.
+ * 하나의 자식 섬이 하나의 부모 섬으로 건너가는 로직을 사용하게 되지만,
+ * 복수의 자식 섬이 하나의 부모 섬으로 건너가는 로직과 동일하게 구현하면 된다.
+ * 
+ */
 public class Main_bj_g3_양_구출_작전 {
 
-	static class Node {
-		int snum; // sheep_num;
-		int wnum; // wolf_num;
-		int parrent; // parent_idx;
+	static class Island {
+		long snum; // sheep_num;
+		long wnum; // wolf_num;
+		int parent; // parent_idx;
+		int child_size = 0; // 연결되어 있는 자식 섬의 개수
 
-		Node(int sn, int wn, int p) {
-			int snum = sn;
-			int wnum = wn;
-			parrent = p;
-		}
-
-		int getDepth(Node[] arr) {
-			if (parrent == -1)
-				return 0;
-			else
-				return arr[parrent].getDepth(arr) + 1;
+		void init(int s, int w, int p) {
+			snum = s;
+			wnum = w;
+			parent = p;
 		}
 
 		@Override
-		public String toString() {
-			return "Node [snum=" + snum + ", wnum=" + wnum + ", parrent=" + parrent + "]";
+		public String toString() { // 디버그용
+			return "Island [snum=" + snum + ", wnum=" + wnum + ", parent=" + parent + "]";
 		}
 
 	}
@@ -31,12 +46,19 @@ public class Main_bj_g3_양_구출_작전 {
 	public static void main(String args[]) throws Exception {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 
+		// 섬 개수를 입력 받는다.
 		int N = Integer.parseInt(br.readLine());
-		Node[] arr = new Node[N + 1];
-		boolean[] hca = new boolean[N + 1]; // has_child_arr
+		Island[] arr = new Island[N + 1];
 
-		arr[1] = new Node(0, 0, -1);
+		// 각 섬을 초기화한다.
+		for (int i = 1; i <= N; i++) {
+			arr[i] = new Island();
+		}
 
+		// 1번 섬은 루트 노드이다.
+		arr[1].init(0, 0, -1);
+
+		// 양이 있는 섬, 혹은 늑대가 있는 섬의 정보를 입력받는다.
 		for (int i = 2; i <= N; i++) {
 			StringTokenizer st = new StringTokenizer(br.readLine());
 			char t = st.nextToken().charAt(0);
@@ -44,58 +66,54 @@ public class Main_bj_g3_양_구출_작전 {
 			int p = Integer.parseInt(st.nextToken());
 
 			if (t == 'S') {
-				arr[i] = new Node(a, 0, p);
+				arr[i].init(a, 0, p);
 			} else { // t=='W'
-				arr[i] = new Node(0, a, p);
+				arr[i].init(0, a, p);
 			}
-
-			hca[p] = true;
+			arr[p].child_size++;
 		}
 
-		// pq에 저장되는 배열
-		// [depth, before, next]
-		PriorityQueue<int[]> pq = new PriorityQueue<>(
-				(o1, o2) -> -Integer.compare(o1[0], o2[0]));
-
-		// leaf Node일 경우 다음 노드를 queue에 탐색 등록
+		// 자식이 없는 섬들을 q에 넣음
+		Queue<Integer> q = new ArrayDeque<>();
 		for (int i = 2; i <= N; i++) {
-			if (hca[i] == false) {
-				pq.offer(new int[] { arr[i].getDepth(arr) - 1, i, arr[i].parrent });
+			if (arr[i].child_size == 0) {
+				q.add(i);
 			}
 		}
 
-		// for (int[] t : pq) {
-		// System.out.println(Arrays.toString(t));
-		// }
-
-		int ans;
+		long ans;
 		while (true) {
-			for (int[] t : pq) {
-				System.out.println(Arrays.toString(t));
-			}
-			System.out.println();
-			int[] info = pq.poll();
-			int depth = info[0];
-			int before = info[1];
-			int next = info[2];
+			int k = q.poll();
 
-			// 다음 노드가 없을 경우 ans를 업데이트하고 종료
-			if (next == -1) {
-				ans = arr[next].snum;
+			// 1번 섬이 활성화 되면 그때 1번 섬의 양의 숫자가 정답.
+			if (k == 1) {
+				ans = arr[k].snum;
 				break;
 			}
-			// 다음 노드가 있을 경우,
-			// 만약 늑대가 다음 노드에 있는 경우 늑대가 양을 잡아먹고
-			// 살아남은 양들이 다음 노드로 이동.
-			else {
-				// 늑대가 양을 잡아먹는다:
-				// 만약 다음 섬의 늑대의 수가 더 많거나 같으면 양은 모두 죽고
-				// 죽은 양 수만큼 배고픈 늑대가 사라진다.
-				if (arr[next].wnum >= info[2]) {
+			// 1번 섬이 아닐 경우,
+			// 만약 늑대가 다음 섬에 있는 경우 늑대가 양을 잡아먹고
+			// 살아남은 양들이 다음 섬로 이동.
+			int p = arr[k].parent;
+			// 만약 다음 섬의 늑대의 수가 더 많거나 같으면 양은 모두 죽고 (==건너오지 못하고)
+			// 죽은 양 수만큼 늑대가 사라진다.
+			if (arr[p].wnum >= arr[k].snum) {
+				arr[p].wnum -= arr[k].snum;
+			}
+			//
+			// 만약 다음 섬의 양의 수가 더 많으면 다음 섬의 수 만큼 이전 섬의 양이 죽고
+			// 다음 섬의 늑대는 모두 사라진다.
+			// 생존한 양은 다음 섬으로 넘어간다.
+			else { // arr[k].snum > arr[p].wnum
+				arr[k].snum -= arr[p].wnum;
+				arr[p].wnum = 0;
+				arr[p].snum += arr[k].snum;
+			}
 
-				}
-				// 만약 다음 섬의 양의 수가 더 많으면 배고픈 늑대는 모두 사라지고
-				// 사라진 늑대만큼 양이 죽는다.
+			// 부모 섬의 자식 개수를 1 감소시킨다.
+			arr[p].child_size--;
+			// 만약 부모 섬의 자식 개수가 0이라면, 해당 섬을 활성화 시킨다. (큐에 넣는다.)
+			if (arr[p].child_size == 0) {
+				q.add(p);
 			}
 		}
 


### PR DESCRIPTION
# 양 구출 작전

 재귀적으로 생각하면, 섬 I와 해당 섬의 자식 섬 c1, c2,... ck가 있을 때,
 
자식 섬들에서 생존한 양들의 합이 섬 I의 늑대의 수보다 많은 경우:
    양은 늑대의 수만큼 잡아먹히고, 섬 I의 늑대가 모두 사라진 후, 남은 양들이 섬 I로 건너온다.

자식 섬들에서 생존한 양들의 합이 섬 I의 늑대의 수보다 적은 경우:
    모든 자식 섬의 양들은 잡아먹히고, 잡아먹힌 양의 수만큼 늑대가 사라진다.
 
다음과 같이 생각할 수 있다.

문제는, 섬의 개수가 10만개가 넘어서 이것을 재귀함수로 구현할 경우, StackOverFlowError가 발생할 것이라는 것이다.
최악으로 10만개의 섬이 일렬로 연결 되어 있으면 재귀적으로 실행 불가능하다.

결국 BottomUp적인 방식으로 구현할 수 밖에 없는데, 이를 위해서 큐를 사용한다.
큐에는 자식이 없는 섬들만 항상 들어간다. 만약 임의의 섬의 탐색이 완료되면 해당 섬의 부모와의 연결을
끊는 방식으로 자식이 없는 섬들을 늘려나간다.
하나의 자식 섬이 하나의 부모 섬으로 건너가는 로직을 사용하게 되지만,
복수의 자식 섬이 하나의 부모 섬으로 건너가는 로직과 동일하게 구현하면 된다.

----------

# 우수 마을

인터넷에서 아이디어를 참고했습니다.

만약 부분집합을 사용하며, 조건에 만족하지 않는 케이스를 중간에 프루닝 하더라도, 경우의 수가 1억이 넘어가기 때문에 제한 시간 안에
실행이 불가능하다.
필연적으로 이 문제는 다이나믹 프로그래밍, 이분탐색, 그래프 이론 중 하나를 사용해야 함을 알 수 있다.

이 문제는 다이나믹 프로그래밍을 사용해서 풀 수 있다.
이 문제의 첫번째 난관은 마을들이 트리 구조로 연결 되어 있으면서, 막상 루트 노드를 특정해주지는 않는다는 것이다.
이것을 해결하기 위해선 트리의 속성에 대한 지식이 필요한데, 임의의 노드를 루트 노드로 선정하면 그 루트 노드를 기준으로 트리가 구성
가능하다.

트리가 계층으로 구성되었으면, 임의의 노드 N이 있다고 하고, 해당 노드의 자식들을 c1, c2, ... ck 라고 할때, 다음과 같은
재귀 식을 세울 수 있다.
노드 N의 인구 population(N)
노드 N을 우수 마을로 선정 했을 때, 해당 노드를 루트로 하는 서브 트리의 우수마을 인구의 합 choice(N)
노드 N을 우수 마을로 선정하지 않았을 때, 해당 노드를 루트로 하는 서브 트리의 우수마을 인구의 합 abandon(N)
choice(N) = population(N) + abandon(c1) + abandon(c2) + ... + abandon(ck)
abandon(N) = Max( choice(c1), abandon(c1) ) + Max( choice(c2), abandon(c2) )
+ ... + Max( choice(ck), abandon(ck) )

헤맸던 부분
3번 조건. 선정되지 못한 마을에 경각심을 불러일으키기 위해서, '우수 마을'로 선정되지 못한 마을은 적어도 하나의 '우수 마을'과는
인접해 있어야 한다.
이 부분을 고민하느라고 문제를 풀지 못했습니다.
인터넷을 보니, 이 부분은 최대값을 구하는 과정에서 자연스럽게 만족된다는 것을 알게 되었습니다.

생각해보면 다음과 같습니다.
만약 마을 A-B-C-D-E가 있다면 X-B-X-X-E로 선택된 경우가 A-X-C-X-E로 선택된 경우보다 더 클때,
abandon(A)는 자연스럽게 X-B-X-X-E로 업데이트 되게 되고, abandon(A)가 choice(A)보다 크게 됨으로 자연스럽게
해답을 구할 수 있습니다.
A-X-X-X-E 는 무조건 A-X-C-X-E보다 작게 됨으로, 선택되지 않는 마을이 우수 마을과 인접하지 않는 경우는 무조건 최대값이
아닙니다.