### PR TITLE
[전소영] 2309 2주차 (양 구출 작전, 우수 마을)

### DIFF
--- a/전소영/2309w2/BJ16437.java
+++ b/전소영/2309w2/BJ16437.java
@@ -1,0 +1,66 @@
+import java.io.*;
+import java.util.*;
+
+// 양 구출 작전
+
+public class BJ16437 {
+
+    static class Node {
+        int id;
+        Node next;
+
+        Node(int id, Node next) {
+            this.id = id;
+            this.next = next;
+        }
+    }
+    static class Island {
+        boolean isWolf;
+        int num;
+        
+        Island(boolean isWolf, int num) {
+            this.isWolf = isWolf;
+            this.num = num;
+        }
+    }
+    static int n;
+    static Island[] islands;
+    static Node[] adj;
+
+    public static void main(String[] args) throws Exception {
+        
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        
+        islands = new Island[n + 1];
+        islands[1] = new Island(false, 0);
+        adj = new Node[n + 1];
+        
+        StringTokenizer st;
+        for(int i = 2; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            boolean isWolf = st.nextToken().charAt(0) == 'W' ? true : false;
+            int num = Integer.parseInt(st.nextToken());
+            int idx = Integer.parseInt(st.nextToken());
+            
+            islands[i] = new Island(isWolf, num);
+            adj[idx] = new Node(i, adj[idx]);
+        }
+        
+        System.out.println(dfs(1));
+    }
+
+    private static long dfs(int id) {
+
+        long total = 0;
+        for(Node node = adj[id]; node != null; node = node.next) {
+            total += dfs(node.id);
+        }
+
+        // 늑대라면, (1) 양의 수가 더 많다면 잡아먹히고 남은 양의 수를 넘겨줌 (2) 늑대의 수가 더 많거나 같다면 0마리를 넘겨줌
+        if(islands[id].isWolf) return (total - islands[id].num) > 0 ? total - islands[id].num : 0;            
+        // 양이라면, 양의 수 만큼 더해서 넘겨줌
+        return islands[id].num + total;                 
+    }
+    
+}

--- a/전소영/2309w2/BJ1949.java
+++ b/전소영/2309w2/BJ1949.java
@@ -1,0 +1,75 @@
+import java.io.*;
+import java.util.*;
+
+// 우수 마을
+
+public class BJ1949 {
+    static class Node {
+        int id;
+        Node next;
+
+        Node(int id, Node next) {
+            this.id = id;
+            this.next = next;
+        }
+    }
+    static int n;
+    static int ans;
+    static int[] population;
+    static int[] visited;
+    static int[][] dp;
+    static Node[] adj;
+    
+    public static void main(String[] args) throws Exception {
+        
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        population = new int[n + 1];
+        visited = new int[n + 1];
+        dp = new int[2][n + 1];
+        adj = new Node[n + 1];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i = 1; i <= n; i++) {
+            population[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for(int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            adj[u] = new Node(v, adj[u]);
+            adj[v] = new Node(u, adj[v]);
+        }
+
+        visited[1]++;
+        dfs(1);
+        System.out.println(Integer.max(dp[0][1], dp[1][1]));
+    }
+
+    private static void dfs(int id) {
+
+        boolean flag = false;
+        for(Node node = adj[id]; node != null; node = node.next) {
+            if(visited[node.id] == 0) {     // 아직 방문하지 않은 노드(자식 노드)들에 대하여
+                visited[node.id] = visited[id] + 1;
+                dfs(node.id);
+                flag = true;
+            }
+        }
+
+        if(flag) {      // 리프 노드가 아닌 경우
+            for(Node node = adj[id]; node != null; node = node.next) {
+                if(visited[node.id] < visited[id]) continue;                // 부모 노드는 패쓰
+                dp[0][id] += Integer.max(dp[0][node.id], dp[1][node.id]);   // id번 마을을 선택하지 않는다면, 자식 노드들에 대하여 (선택하지 않은 경우, 선택한 경우) 중 더 큰 값의 경우를 더해줌
+                dp[1][id] += dp[0][node.id];                                // id번 마을을 선택한다면, 자식 노드들에 대하여 (선택한 경우)를 더해줌
+            }
+            dp[1][id] += population[id];                                    // id번 마을을 선택했으므로, id번 마을의 인구수를 더해줌
+        }
+        else {          // 리프 노드인 경우
+            dp[0][id] = 0;                  // id번 마을을 선택하지 않은 경우
+            dp[1][id] = population[id];     // id번 마을을 선택한 경우
+        }
+    }
+}


### PR DESCRIPTION
# 양 구출 작전
## 접근법
- 리턴 값이 있는 DFS 탐색하기
- `dfs(id)` 함수는, id번 섬까지 도달할 수 있는 구출 가능한 양의 수를 얻음
- 처음에 dfs(1)을 호출해서 탐색을 시작함
- for문으로 연결된 모든 섬들을 돌면서 구출 가능한 총 양의 수를 `total` 변수에 담음
- for문이 끝났다면, id번 섬이 늑대 or 양인지에 따라 리턴 값이 달라짐
- 늑대라면, total에 담긴 구출 가능한 양의 수와 id번째 섬에 있는 늑대의 수를 비교해야 함
    (1) 늑대의 수가 더 많거나 같다면, 구출 가능한 양은 다 잡아먹히므로 0을 리턴
    (2) 양의 수가 더 많다면, 늑대와 양의 수의 차(잡아먹히고 남은 양의 수)를 리턴
- 양이라면, total에 id번째 섬에 있는 양의 수를 합쳐서 리턴하면 됨

# 우수 마을
> 며칠 전 같은 유형의 문제를 풀어서 혼자 풀 수 있을 줄 알았는데.. 결국 이전 풀이를 참고함
> Tree Dynamic Programming 유형으로, 풀이 구조를 어느정도 익혀야 풀 수 있을 듯 함
## 접근법
- 선택한 노드가 `우수 마을인지 아닌지` 두 가지 경우에 대한 인구 수의 총합을 저장하고 있어야함
- 2차원 `dp[][]` 배열을 사용해
    `dp[0][x]`: x번째 마을이 우수 마을이 아닐 때의 총합
    `dp[1][x]`: x번째 마을이 우수 마을일 때의 총합
    을 저장함
- `visited[]` 배열의 타입은 `int`로 선언했는데, 트리 구조이므로 인접 노드에 대해서 탐색할 때 자식 노드만 탐색하기 위해서임
- visited[1] = 1로 설정해, 각 노드의 depth를 저장함
### dfs(int id) 함수
- main()에서 dfs(1)을 호출함 (모든 마을은 연결되어 있기에 아무 노드나 호출해도 무관)
- for문을 돌아 인접 노드를 탐색하면서 visited[]에 depth를 기록하고, 또다시 dfs()를 호출함
- for문이 끝났다면, 리프 노드인 경우와 아닌 경우로 나뉨

1. 리프 노드가 아니라면, id번째 노드의 자식 노드들에 대하여 dp[0][id]와 dp[1][id] 값을 구해야 함
1.1 dp[0][id]는 id번째 노드를 우수 마을로 선정하지 않겠다는 의미
  - 자식 노드는 우수 or 비우수 모두 가능하므로, 더 큰 값을 더해줌
1.2 dp[1][id]는 id번째 노드를 우수 마을로 선정하겠다는 의미
  - 자식 노드는 비우수 마을만 가능하므로, 비우수 마을의 값을 더해줌
  - 그리고 id번째 인구수도 더함

2. 리프 노드라면, 
    id번째 노드를 우수 마을로 선택하는 경우와 선택하지 않는 경우로 나누어 dp[][] 값에 저장함

- 최종적으로 main()에서 dp[0][1]과 dp[1][1] 중 더 큰 값, 즉 1번째 마을을 우수 마을로 정한 경우와 우수 마을로 정하지 않은 경우 중 총합이 더 큰 경우를 답으로 출력함
        
