### PR TITLE
[김지현] Solved BOJ 1939 중량제한, 1113 수영장만들기 #0926

### DIFF
--- a/김지현/0926/Main_boj_1113_수영장만들기.java
+++ b/김지현/0926/Main_boj_1113_수영장만들기.java
@@ -1,0 +1,82 @@
+package a0914;
+
+import java.util.*;
+import java.io.*;
+
+public class Main_boj_1113_수영장만들기 {
+	
+	static int N, M, result;
+	static int max=Integer.MIN_VALUE; // 최대 높이
+	static int[][] pool;
+	static final int[] dx = {-1, 0, 1, 0};
+	static final int[] dy = {0, -1, 0, 1};
+	static boolean[][] v;
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		// 입력 받기
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		pool = new int[N][M];
+		
+		for(int i=0; i<N; i++) {
+			String input = br.readLine();
+			for(int j=0; j<M; j++) {
+				int m = input.charAt(j) - '0';
+				pool[i][j] = m;
+				if(max < m) max = m; // 최고 높이 구하기
+			}
+		}
+		
+		for(int h=1; h<=max; h++) {
+			v = new boolean[N][M];
+			for(int i=0; i<N; i++) {
+				for(int j=0; j<M; j++) {
+					if(pool[i][j] < h && !v[i][j]) {
+						result += bfs(i, j, h);
+					}
+				}
+			}
+		}
+		System.out.println(result);
+		br.close();
+	}
+	
+	private static int bfs(int x, int y, int h) {
+		Queue<int[]> q = new ArrayDeque<>();
+		
+		int cnt = 1;
+		boolean flag = true;
+		
+		q.offer(new int[] {x, y});
+		v[x][y] = true;
+		
+		
+		while(!q.isEmpty()) {
+			int[] cur = q.poll();
+			for(int d=0; d<4; d++) {
+				int nx = cur[0] + dx[d];
+				int ny = cur[1] + dy[d];
+				
+				if(!isRange(nx, ny)) {
+					flag = false;
+					continue;
+				}
+				if(pool[nx][ny] < h && !v[nx][ny]) {
+					q.offer(new int[] {nx, ny});
+					v[nx][ny] = true;
+					cnt++;
+				}
+			}
+		}
+		if(flag) return cnt;
+		return 0;
+	}
+	
+	private static boolean isRange(int x, int y) {
+		if(0 <= x && x < N && 0 <= y && y < M) return true;
+		return false;
+	}
+}

--- a/김지현/0926/Main_boj_1939_중량제한2.java
+++ b/김지현/0926/Main_boj_1939_중량제한2.java
@@ -1,0 +1,80 @@
+package a0925;
+
+import java.io.*;
+import java.util.*;
+
+public class Main_boj_1939_중량제한2 {
+	
+	static int N, start, end, result;
+	static List<int[]>[] map;
+	static boolean[] v;
+	
+	public static void main(String[] args) throws Exception {
+//		System.setIn(new FileInputStream("res/input_boj_1939.txt"));
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		// map 초기화
+		map = new List[N+1];
+		for(int i=1; i<=N; i++) {
+			map[i] = new ArrayList<>();
+		}
+		
+		int c_max = Integer.MIN_VALUE; // c 최대값 저장
+		
+		for(int i=0; i<M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			int c = Integer.parseInt(st.nextToken());
+			
+			map[a].add(new int[] {b, c});
+			map[b].add(new int[] {a, c});
+			
+			c_max = Math.max(c_max, c);
+		}
+		st = new StringTokenizer(br.readLine());
+		start = Integer.parseInt(st.nextToken());
+		end = Integer.parseInt(st.nextToken());
+		
+		// 이분탐색
+		int left = 0;
+		int right = c_max;
+		while(left <= right) {
+			int mid = (left + right) / 2;
+			v = new boolean[N+1];
+			boolean isGo = bfs(mid);
+			if(isGo) {
+				result = Math.max(mid, result);
+				left = mid+1;
+			} else {
+				right = mid-1;
+			}
+
+		}	
+		System.out.println(result);	
+		br.close();
+	}
+	
+	private static boolean bfs(int mid) {
+		Queue<Integer> queue = new ArrayDeque<>();
+		v[start] = true;
+		queue.offer(start);
+		while(!queue.isEmpty()) {
+			int cur = queue.poll();
+			if(cur == end) return true;
+			for(int[] m : map[cur]) {
+				int to = m[0];
+				int cost = m[1];
+				if(!v[to] && cost >= mid) {
+					queue.offer(to);
+					v[to] = true;
+				}
+			}
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
### 1939 중량제한
처음 풀 때는,
모든 경로를 돌면서, 각 경로의 중량치 최솟값을 구하는 방식으로 풀었는데` (dfs + 백트래킹)`
**시간 초과** 났습니다. (이유 : **백트래킹 시간복잡도가 O(2^n) 라서**)

그래서, `bfs + 이분탐색` 으로 풀었습니다.
중량치를 이분탐색으로 (0 부터 중량 최대값)까지 돌면서 가능한지 체크하는 방식으로 풀었습니다!

### 1113 수영장만들기
처음 문제 볼 때, 이해가 쉽고 간단해보였는데, 바깥쪽 테두리 부터 안쪽으로 돌면서, 확인하려고 하니, 구현이 어려웠습니다.

[풀이 방법]
- 물의 높이를 1부터 수영장의 최대 높이까지 1층씩 올리면서 탐색합니다.
- h 층의 행, 열을 돌면서, h보다 낮은 높이가 있다면 bfs 호출.
  - 4방 탐색하면서 범위 안에 있고, 방문하지 않고 현재 높이보다 낮다면, 큐에 넣습니다.
  - 범위를 벗어나게 되면, 물을 담을 수 없습니다. `flag = false` 로 확인.
- bfs 에서 반환한 높이를 모두 더하면, 채울 수 있는 물의 양 이 됩니다.

참고 : [https://imgoood.tistory.com/97](https://imgoood.tistory.com/97)