### PR TITLE
[전소영] 2310 1주차 (가장 긴 바이토닉 부분 수열, 어항 정리)

### DIFF
--- a/전소영/2310w1/BJ11054.java
+++ b/전소영/2310w1/BJ11054.java
@@ -1,0 +1,56 @@
+import java.io.*;
+import java.util.*;
+
+// 가장 긴 바이토닉 부분 수열
+
+public class BJ11054_2 {
+    
+    static int n;
+    static int[] arr;
+    static int[][] dp;
+
+    public static void main(String[] args) throws Exception {
+        
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        arr = new int[n];
+        dp = new int[2][n];
+        for(int i = 0; i < 2; i++) {
+            Arrays.fill(dp[i], 1);
+        }
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        System.out.println(solution());
+    }
+
+    private static int solution() {
+        int maxLength = 0;
+        // i번째 수를 기준으로 앞쪽은 감소, 뒷쪽은 증가하는 경우의 최장 길이 구하기
+        for(int i = 0; i < n; i++) {
+            getDecreaseLength(i);
+            getIncreaseLength(i);
+            maxLength = Integer.max(maxLength, dp[0][i] + dp[1][i] - 1);
+        }
+        return maxLength;
+    }
+    
+    private static void getDecreaseLength(int x) {
+        for(int i = 1; i <= x; i++) {
+            for(int j = i - 1; j >= 0; j--) {
+                if(arr[i] > arr[j]) dp[0][i] = Integer.max(dp[0][i], dp[0][j] + 1);
+            }
+        }
+    }
+
+    private static void getIncreaseLength(int x) {
+        for(int i = n - 1; i >= x; i--) {
+            for(int j = i + 1; j < n; j++) {
+                if(arr[j] < arr[i]) dp[1][i] = Integer.max(dp[1][i], dp[1][j] + 1);
+            }
+        }
+    }
+}
+

--- a/전소영/2310w1/BJ23291.java
+++ b/전소영/2310w1/BJ23291.java
@@ -1,0 +1,189 @@
+import java.io.*;
+import java.util.*;
+
+// 어항 정리
+
+public class BJ23291 {
+
+    static final int MAX = 99999;
+    static int n, k;
+    static int cnt;                     // 어항 정리 횟수
+    static int idx, row, col;           // firstFly()에서 사용되는 변수
+    static int[][] arr;
+    static int[][] temp;
+
+    public static void main(String[] args) throws Exception {
+        
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        arr = new int[n + 1][n + 1];
+        temp = new int[n + 1][n + 1];
+        
+        st = new StringTokenizer(br.readLine());
+        int min = MAX;
+        int max = 0;
+        for(int i = 1; i <= n; i++) {
+            arr[n][i] = Integer.parseInt(st.nextToken());
+            if(min > arr[n][i]) min = arr[n][i];
+            if(max < arr[n][i]) max = arr[n][i];
+        }
+
+        if(max - min > k) solution();
+        System.out.println(cnt);
+    }
+
+    private static void solution() {
+
+        cnt = 1;
+        while(true) {
+            insertOnePutOne();      // 물고기 수 가장 적은 어항에 물고기 한 마리 넣고, 가장 왼쪽 어항을 오른쪽 어항 위 올리기
+            flyFirst();             // 첫번째 방식의 공중부양
+            adjustFishNumber();     // 물고기 수 조절하기
+            putLine();              // 일렬로 놓기
+            flySecond();            // 두번째 방식의 공중부양
+            adjustFishNumber();     // 물고기 수 조절하기
+            putLine();              // 일렬로 놓기
+            cnt++;
+        }
+    }
+
+    private static void insertOnePutOne() {
+        
+        int min = MAX;
+        ArrayDeque<Integer> minIdx = new ArrayDeque<>();
+        for(int i = 1; i <= n; i++) {
+            if(min > arr[n][i]) {
+                minIdx.clear();
+                min = arr[n][i];
+                minIdx.add(i);
+            }
+            else if(min == arr[n][i]) {
+                minIdx.add(i);
+            }
+        }
+
+        while(!minIdx.isEmpty()) {
+            arr[n][minIdx.poll()]++;
+        }
+
+        arr[n - 1][2] = arr[n][1];
+        arr[n][1] = 0;
+    }
+
+    private static void flyFirst() {
+        
+        idx = 2;
+        row = 1;
+        col = 2;
+
+        int time = 0;
+        while(true) {
+
+            if(idx + row + col - 1 > n) break;
+            moveFirst();
+            idx += row;
+            if (time++ % 2 == 0) row++;
+            else col++;
+        }
+    }
+
+    private static void moveFirst() {
+
+        for(int j = idx; j < idx + row; j++) {
+            for(int i = n; i > n - col; i--) {
+                arr[n - row + (j - idx)][idx + row + (n - i)] = arr[i][j];
+                arr[i][j] = 0;
+            }
+        }
+    }
+    
+    private static void adjustFishNumber() {
+        
+        for(int i = 1; i <= n; i++) {
+            for(int j = 1; j <= n; j++) {
+                // 인접 열 탐색
+                if(j < n && arr[i][j] != 0 && arr[i][j + 1] != 0) {
+                    int d = Math.abs(arr[i][j] - arr[i][j + 1]) / 5;
+                    if(d > 0) {
+                        if(arr[i][j] > arr[i][j + 1]) {
+                            temp[i][j] -= d;
+                            temp[i][j + 1] += d;
+                        }
+                        else {
+                            temp[i][j] += d;
+                            temp[i][j + 1] -= d;
+                        }
+                    }
+                }
+
+                // 인접 행 탐색
+                if(i < n && arr[i][j] != 0 && arr[i + 1][j] != 0) {
+                    int d = Math.abs(arr[i][j] - arr[i + 1][j]) / 5;
+                    if(d > 0) {
+                        if(arr[i][j] > arr[i + 1][j]) {
+                            temp[i][j] -= d;
+                            temp[i + 1][j] += d;
+                        } 
+                        else {
+                            temp[i][j] += d;
+                            temp[i + 1][j] -= d;
+                        } 
+                    }
+                }
+            }
+        }
+
+        int min = MAX;
+        int max = 0;
+        for(int i = 1; i <= n; i++) {
+            for(int j = 1; j <= n; j++) {
+                arr[i][j] += temp[i][j];
+                temp[i][j] = 0;
+
+                if(arr[i][j] == 0) continue;
+                min = Integer.min(min, arr[i][j]);
+                max = Integer.max(max, arr[i][j]);
+            }
+        }
+        if(max - min <= k) {
+            System.out.println(cnt);
+            System.exit(0);
+        }
+    }
+    
+    private static void putLine() {
+
+        int pos = 1;
+        for(int j = idx; j < idx + row; j++) {
+            for(int i = n; i > n - col; i--) {
+                arr[n][pos++] = arr[i][j];
+                arr[i][j] = 0;
+            }
+        }
+    }
+    
+    private static void flySecond() {
+        
+        // 1번 작업
+        for(int i = 1; i <= n / 2; i++) {
+            arr[n - 1][n + 1 - i] = arr[n][i];
+            arr[n][i] = 0;
+        }
+
+        // 2번 작업
+        int threeQuarters = n - n  / 4;
+        for(int i = n - 1; i <= n; i++) {
+            for(int j = threeQuarters; j > n / 2; j--) {
+                arr[2 * n - 3 - i][threeQuarters + (threeQuarters - j + 1)] = arr[i][j];
+                arr[i][j] = 0;
+            }
+        }
+
+        idx = threeQuarters + 1;
+        row = n / 4;
+        col = 4;
+    }
+    
+}


### PR DESCRIPTION
# 가장 긴 바이토닉 부분 수열
## 접근법
- 하나의 값을 꼭대기로 정하고, 꼭대기 기준 앞으로 앞뒤를 확인하자
- 앞인 경우, 꼭대기를 시작으로 0번째까지 감소하는 수열의 최장 길이 구하기
- 뒤인 경우, n - 1 번째를 시작으로 꼭대기까지 증가하는 수열의 최장 길이 구하기
- 두 길이를 합친 후 -1을 해서 답을 도출 (꼭대기는 중복되므로)

## 변수 선언
- `dp[][]`를 2차원 배열로 선언
- 0번째는 감소 배열, 1번째는 증가 배열을 위해 값 저장
- 처음에 모두 1로 초기화

## getDecreaseLength(), getIncreaseLength() 함수
- 이중 for문을 돌면서 탐색, i는 꼭대기가 될 수 있는 값

# 어항 정리
## 접근법
- 문제에서 하라는 대로 하자
- 각각의 작업을 함수로 쪼갬
- 처음에 main()에서 0번째 정리에 물고기 수 차이가 k 이하가 될 수 있는지 판단해줌
- 좌표는 1부터 n까지 사용

## insertOnePutOne() 함수
| 물고기 수 가장 적은 어항에 물고기 한 마리 넣고, 가장 왼쪽 어항을 오른쪽 어항 위 올리기
- 물고기 수가 가장 적은 물고기가 여러 마리일 수 있으므로 `minIdx`라는 큐에 가장 작은 값의 index를 담음
- 그리고 (n, 1)에 있는 물고기 한 마리를 (n - 1, 2)로 올려줌

## flyFirst() 함수
| 첫번째 방식의 공중부양
- idx, row, col 세 변수를 사용해서 배열을 옮겨줌
- idx번째 열을 시작으로 row * col 사이즈의 직사각형 배열을 공중부양 시켜 옮긴다는 의미
- (idx, row, col)값이 (2, 1, 2), (3, 2, 2), (5, 2, 3), (7, 3, 3), (10, 3, 4), (13, 4, 4), ... 라는 규칙이 있음
- 짝수, 홀수번째마다 row 혹은 col이 증가함
- idx, row, col을 인자로 moveFirst() 함수를 호출함 (실제 파라미터로 넘기진 않음. flySecond() 함수에서 사용하기에 전역으로 선언)

## moveFirst() 함수
| 첫번째 방식의 공중부양에서 실제 배열을 옮기는 행위
- 이중 for문으로 전체 직사각형 모양의 어항들을 매핑되는 위치에 바로바로 옮겨줌
(이 계산이 가장 까다로웠음 ㅠ)

## adjustFishNumber() 함수
| 물고기 수 조절하기
- 이중 for문을 돌면서 0이 아닌 어항에 대해 인접 열, 인접 행의 어항과 비교해줌
- temp[][]에 변경되는 d값만큼 저장해둠
- temp에 저장을 마쳤으면, arr에 반영해줌
- 이때 물고기 수가 바뀌므로 max, min 값도 다시 찾아서 어항 정리를 종료할 수 있는지 판별해줌
- `max - min <= k`를 만족한다면 cnt 값을 출력하고 바로 프로그램 종료

## putLine() 함수
| 일렬로 놓기
- moveFirst()에서 마지막으로 사용했던 idx, row, col 값을 활용함
- 위로 쌓이지 못했던 마지막 직사각형 row * col 크기의 값들을 n번째 행으로 옮겨줌

## flySecond() 함수
| 두번째 방식의 공중부양
### 1번 작업
- `n / 2` 크기만큼 위로 옮김

### 2번 작업
- `n / 4` 크기만큼 위로 옮김
- 2개의 행이므로 for문을 사용함
