### PR TITLE
[김지현] 11054 가장 긴 바이토닉 부분 수열 #1003

### DIFF
--- a/김지현/1003/Main_boj_11054_가장긴바이토닉부분수열.java
+++ b/김지현/1003/Main_boj_11054_가장긴바이토닉부분수열.java
@@ -1,0 +1,50 @@
+import java.util.*;
+import java.io.*;
+
+// 14880KB	160ms
+public class Main_boj_11054_가장긴바이토닉부분수열 {
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        // 입력받기
+        int N = Integer.parseInt(br.readLine());
+        int[] list = new int[N];
+
+        st = new StringTokenizer(br.readLine());
+        for(int i=0; i<N; i++){
+            list[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // 왼쪽 -> 오른쪽 오름차순 dp 구하기(LIS 알고리즘)
+        int[] dp = new int[N];
+        for(int i=0; i<N; i++){
+            dp[i] = 1;
+            for(int j=0; j<i; j++){
+                if(list[i] > list[j]) dp[i] = Math.max(dp[j]+1, dp[i]);
+
+            }
+        }
+
+        // 오른쪽 -> 왼쪽 오름차순 dp 구하기
+        int[] dp_2 = new int[N];
+        for(int i=N-1; i>=0; i--){
+            dp_2[i] = 1;
+            for(int j=N-1; j>i; j--){
+                if(list[i] > list[j]) dp_2[i] = Math.max(dp_2[j]+1, dp_2[i]);
+            }
+        }
+//        System.out.println(Arrays.toString(dp));
+//        System.out.println(Arrays.toString(dp_2));
+
+        // 두 배열의 합의 최댓값 -1
+        int res = 0;
+        for(int i=0; i<N; i++){
+            res = Math.max(res, dp[i]+dp_2[i]);
+        }
+
+        System.out.println(res-1);
+        br.close();
+
+    }
+}


### PR DESCRIPTION
## 11054 가장 긴 바이토닉 부분 수열(G4)
예전에 비슷한 문제를 풀었어서, 그 때 사용했던 방법을 이용해서 풀었습니다. (LIS 알고리즘)
- dp 배열 2개를 각각 `왼쪽->오른쪽 오름차순`, `오른쪽->왼쪽 오름차순` 을 각각 구한 후에,
- 각 왼쪽, 오른쪽이 최대가 되어야 하므로, 두 배열을 더한 후 `최대값에서 -1` 을 해서 구했습니다.
(최대값 -1 을 하는 이유는, 양쪽 dp에서 해당 위치를 포함해서 계산되므로, 중복된 것을 빼기 위함입니다.)