### PR TITLE
[김지현] BOJ 12784 인하니카공화국, 26093 고양이 목에 리본 달기 #1010

### DIFF
--- a/김지현/1010/Main_boj_12784_인하니카공화국.java
+++ b/김지현/1010/Main_boj_12784_인하니카공화국.java
@@ -1,0 +1,59 @@
+import java.io.*;
+import java.util.*;
+
+public class Main_boj_12784_인하니카공화국 {
+
+    static int INF = Integer.MAX_VALUE;
+    static int N, M;
+    static List<int[]>[] adj;
+
+    public static void main(String[] args) throws Exception {
+//        System.setIn(new FileInputStream("res/input_boj_12784.txt"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+
+        int T = Integer.parseInt(br.readLine());
+        for(int tc=1; tc<=T; tc++){
+            // 입력받기
+            st = new StringTokenizer(br.readLine());
+            N = Integer.parseInt(st.nextToken());
+            M = Integer.parseInt(st.nextToken());
+
+            // 초기화
+            adj = new List[N+1];
+            for(int i=1; i<=N; i++){
+                adj[i] = new ArrayList<>();
+            }
+
+            // 인접리스트 값 넣기
+            for(int m=0; m<M; m++){
+                st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+                int c = Integer.parseInt(st.nextToken());
+
+                adj[a].add(new int[]{b,c});
+                adj[b].add(new int[]{a,c});
+            }
+
+            int result = dfs(1, -1, INF);
+
+            sb.append((result==INF ? 0 : result) + "\n"); // 1만 입력으로 들어온 경우 예외 처리
+        }
+        System.out.println(sb.toString());
+        br.close();
+    }
+
+    private static int dfs(int now, int past, int bomb){
+        int res = 0;
+        for(int[] nxt : adj[now]){ // 자식 노드를 돌면서
+            if(past != nxt[0]){ // 사이클이 돌지 않으면(바로 위와 같지 않으면)
+                res += dfs(nxt[0], now, nxt[1]); // res에 더해주기
+            }
+        }
+        if(res == 0) res = bomb; // 리프 노드인 경우 해당 다이너마이트 개수를 그대로 넣기
+        return Math.min(res, bomb); // 내 다이너마이트 개수와 아래 자식 개수를 비교해서, 작은거 반환
+    }
+}

--- a/김지현/1010/Main_boj_26093_고양이목에리본달기.java
+++ b/김지현/1010/Main_boj_26093_고양이목에리본달기.java
@@ -1,0 +1,63 @@
+package a1010;
+
+import java.io.*;
+import java.util.*;
+
+
+//90796KB	612ms
+public class Main_boj_26093_고양이목에리본달기 {
+	
+	static int N, K;
+	static int[][] dp;
+	static int max=0, preMax=0;
+	
+	public static void main(String[] args) throws Exception {
+		System.setIn(new FileInputStream("res/input_boj_26093.txt"));
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		// 입력받기
+		N = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		dp = new int[N][K];
+		
+		for(int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			
+			for(int j=0; j<K; j++) {
+				dp[i][j] = Integer.parseInt(st.nextToken());
+				
+				if(i == 0) {
+					if(dp[i][j] >= max) {
+						preMax = max;
+						max = dp[i][j];
+					} else if(dp[i][j] > preMax) {
+						preMax = dp[i][j];
+					}
+				}
+			}
+		}
+		
+		for(int i=1; i<N; i++) {
+			int newMax=0, newPreMax=0;
+			for(int j=0; j<K; j++) {
+				dp[i][j] += (max == dp[i-1][j]) ? preMax : max;
+				
+				if(dp[i][j] >= newMax) {
+					newPreMax = newMax;
+					newMax = dp[i][j];
+				} else if (dp[i][j] > newPreMax) {
+					newPreMax = dp[i][j];
+				}
+			}
+			max = newMax;
+			preMax = newPreMax;
+		}
+		
+		Arrays.sort(dp[N-1]);
+		System.out.println(dp[N-1][K-1]);
+		br.close();
+	}
+}
+
+// 바로 직전 꺼에만 영향을 받음!


### PR DESCRIPTION
## 12784 인하니카공화국(G3)
- 입력 : 인접리스트
- DFS 탐색
  - now의 인접리스트를 탐색하면서 
    - 트리이므로, 바로 지난노드(past)와 현재만 비교해서, 사이클이 아니라면 다음 배열을 dfs돌려서, res 값에 더해준다.
  - 리프 노드라면(다음 인접리스트를 돌지 않는다면), 해당 bomb 값을 그대로 리턴
  - 인접리스트 모두 돌았다면, 자식노드의 bomb 합 vs 내 다이너마이트 개수 를 비교해서, 최솟값을 반환함.
- 1 하나만 입력이 들어오는 경우를 예외처리 해서 출력
 
> [주의] 
`두 섬을 연결하는 다리를 최소한의 개수로 만들어, 모든 섬 간의 왕래가 가능하도록 만들었다` 
➔ **`최소신장트리`** 라는 점을 몰라서, 사이클이 생기는 경우를 생각하느라...시간 너무 오래 썼습니다..ㅜ

## 26093 고양이 목에 리본 달기 (G3)
### 첫번째 풀이(시간초과)
- 바로 직전 인덱스에만 영향을 받음!
- `dp[최선 만족도][차선 만족도] `를 저장하고, `past_idx[최선만족도인덱스][차선만족도인덱스]` 를 저장
- 입력받으면서, 각 인덱스와 같지 않으면, 최선만족도부터 더해주면서, 인덱스를 갱신하는 방식
으로 풀었더니, 시간초과 났습니다.

### 정답 풀이(소영이 코드 참고했습니다.)
- 직전 인덱스로 체크 안하는 것은 생각도 못했는데!! 이 점이 인상 깊어 참고했습니다.
- `max(가장 큰값), preMax(그 다음 큰값) `만 가지고, 바로 위 행이 max가 아니라면, max를 더해주고, max라면, preMax를 더해주는 방식으로 풀었습니다.