### PR TITLE
[전소영] 2310 2주차 (인하니카 공화국, 고양이 목에 리본 달기)

### DIFF
--- a/전소영/2310w2/BJ12784.java
+++ b/전소영/2310w2/BJ12784.java
@@ -1,0 +1,65 @@
+import java.io.*;
+import java.util.*;
+
+// 인하니카 공화국
+
+public class BJ12784 {
+
+    static int n;
+    static ArrayList<int[]>[] adj;
+    static boolean[] visited;
+    
+    public static void main(String[] args) throws Exception {
+        
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int tc = Integer.parseInt(br.readLine());
+        
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+        for(int t = 0; t < tc; t++) {
+            st = new StringTokenizer(br.readLine());
+            n = Integer.parseInt(st.nextToken());
+            int m = Integer.parseInt(st.nextToken());
+            adj = new ArrayList[n + 1];
+            for(int i = 1; i <= n; i++) {
+                adj[i] = new ArrayList<>();
+            }
+            visited = new boolean[n + 1];
+            
+            for(int i = 0; i < m; i++) {
+                st = new StringTokenizer(br.readLine());
+                int u = Integer.parseInt(st.nextToken());
+                int v = Integer.parseInt(st.nextToken());
+                int d = Integer.parseInt(st.nextToken());
+                adj[u].add(new int[] {v, d});
+                adj[v].add(new int[] {u, d});
+            }
+            
+            visited[1] = true;
+            int ans = dfs(1, Integer.MAX_VALUE);
+            ans = (ans == Integer.MAX_VALUE) ? 0 : ans;
+            sb.append(ans + "\n");
+        }
+
+        System.out.println(sb.toString());
+    }
+    
+    private static int dfs(int x, int weight) {     // weight은 x번 섬으로 갈 때의 다이너마이트 수
+        
+        boolean flag = false;
+        int total = 0;
+        for(int i = 0; i < adj[x].size(); i++) {
+            int n = adj[x].get(i)[0];
+            int d = adj[x].get(i)[1];
+            
+            if(visited[n]) continue;
+            visited[n] = true;
+            total += dfs(n, d);
+            flag = true;
+        }
+        
+        if(flag) return Integer.min(weight, total);
+        return weight;
+    }
+        
+}

--- a/전소영/2310w2/BJ26093.java
+++ b/전소영/2310w2/BJ26093.java
@@ -1,0 +1,52 @@
+import java.io.*;
+import java.util.*;
+
+// 고양이 목에 리본 달기
+
+public class BJ26093 {
+
+    public static void main(String[] args) throws Exception {
+        
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        int[][] dp = new int[n + 1][k];
+        int max = 0, preMax = 0;
+
+        for(int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j = 0; j < k; j++) {
+                dp[i][j] = Integer.parseInt(st.nextToken());
+                if(i == 1) {
+                    if(dp[i][j] >= max) {
+                        preMax = max;
+                        max = dp[i][j];
+                    }
+                    else if(dp[i][j] > preMax) {
+                        preMax = dp[i][j];
+                    }
+                }
+            }
+        }
+
+        for(int i = 2; i <= n; i++) {
+            int newMax = 0, newPreMax = 0;
+            for(int j = 0; j < k; j++) {
+                dp[i][j] += (max == dp[i - 1][j]) ? preMax : max; 
+                if(dp[i][j] >= newMax) {
+                    newPreMax = newMax;
+                    newMax = dp[i][j];
+                }
+                else if(dp[i][j] > newPreMax) {
+                    newPreMax = dp[i][j];
+                }
+            }
+            max = newMax;
+            preMax = newPreMax;
+        }
+
+        Arrays.sort(dp[n]);
+        System.out.println(dp[n][k - 1]);
+    }
+}


### PR DESCRIPTION
# 인하니카 공화국
## 접근법
저번에 풀었던 DFS 문제와 유사했다.
DFS 함수에 리턴 값을 주고 리프 노드인지에 따라 다르게 처리해줘야 했다.
왜냐면 다리가 하나 밖에 없는 섬을 구분해야 했는데, 그게 곧 리프 노드이다.

## dfs() 함수
파라미터 값으로 `int x, int weight`을 주었다.
x번 섬으로 갈 때의 다이너마이트 수, weight 값을 넘겨주었다.
리턴 값의 의미는 리프 노드까지 탐색한 후, x번 섬까지 오는데 필요한 최소 weight 값을 의미한다.

그러므로 리프 노드라면, 바로 weight 값을 리턴하고
리프 노드가 아니라면, 자신과 연결된 모든 섬들에 대해(방문했던 섬 제외) weight 값의 합을 `total` 변수에 담고
weight 값과 total 값 중 더 작은 값을 리턴한다.

# 고양이 목에 리본 달기
## 접근법
보자마자 DP네, 이전에 유사한 문제를 풀어서 그대로 점화식 사용했더니 시간초과 발생
어떻게 시간을 줄일 수 있을지 고민하는 게 포인트였다.

## 시간초과 풀이
이차원 배열 dp 배열 만들고 i번째 고양이라면, i번째 고양이가 0~k번 리본을 선택한 경우에 따라서 dp[i][0], dp[i][1], ..., dp[i][k-1]을 채워야 했음
이때 dp[i][j]라면, dp[i-1][0], dp[i-1][1], ..., dp[i-1][k-1] 중 dp[i-1][j]를 제외하고 최댓값을 찾아 더해주는 방식이었다.
dp[i-1][j]를 제외하는 이유는 dp[i][j]와 같은 리본이기 때문

## 정답 풀이
위 풀이에서 시간초과가 발생한 이유는 k의 최댓값은 10000인데, 최악의 경우 모든 고양이에 대해 10000개의 값 중 최댓값을 골라야 하기 때문이라고 판단했다.
그래서 이 부분을 어떻게 줄일 수 있을까 고민했다.

결국 i번째 고양이의 각 리본에 대한 dp[][]값을 구할 때는
i-1번째 고양이까지의 `max(최댓값)`, `preMax(그 다음 최댓값)` 이 두 값만 필요하다.


왜냐면 dp[i][j]의 값을 채우기 위해서,
`max`가 j 리본으로부터 만들어진 값이 아니라면, 그대로 `max`을 사용하고
`max`가 j 리본으로부터 만들어진 값이라면, `preMax`을 사용하면 되기 때문이다.

## 33번째 줄부터 2중 for문
dp[][]를 채워가는 코드이다.
각 고양이에 대해 최댓값과 그 다음 최댓값을 업데이트 해주기 위해 `newMax`와 `newPreMax` 변수를 사용했다.

36번째 줄
``` java
dp[i][j] += (max == dp[i - 1][j]) ? preMax : max; 
```
`max`가 j 리본으로부터 만들어진 값인지 아닌지 판단해서 `preMax` 혹은 `max`를 더해준다.
max와 preMax는 어차피 dp[i-1][]의 값 중 하나이고, j 리본에 해당하는 값이라면 max 값과 일치하므로 위와 같이 판단할 수 있다.
 

 