### PR TITLE
[김준엽] - 상어중학교 && 마법사상어와 블리자드

### DIFF
--- a/김준엽/20231017/마법사상어와블리자드.java
+++ b/김준엽/20231017/마법사상어와블리자드.java
@@ -1,0 +1,180 @@
+
+import java.io.*;
+import java.util.*;
+
+public class 마법사상어와블리자드 {
+    static int N, M;
+    static int snail[][], board[][], dx[] = { 0, 1, 0, -1 }, dy[] = { -1, 0, 1, 0 };
+    static int mdx[] = { -1, 1, 0, 0 }, mdy[] = { 0, 0, -1, 1 };
+    static ArrayList<Integer> marbles;
+    static int popCount, ans;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        snail = new int[N][N];
+        board = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                board[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        board[N / 2][N / 2] = -1;
+        makeSnail();
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int dir = Integer.parseInt(st.nextToken());
+            int count = Integer.parseInt(st.nextToken());
+            blizzard(dir - 1, count);
+            pushReady();
+            while (true) {
+                popCount = 0;
+                pop();
+                if (popCount == 0)
+                    break;
+            }
+            changeReady();
+            change();
+        }
+        System.out.println(ans);
+    }
+
+    static void print() {
+        for (int i = 0; i < N; i++) {
+            System.out.println(Arrays.toString(board[i]));
+        }
+        System.out.println();
+    }
+
+    static void makeSnail() {
+        int x = N / 2;
+        int y = N / 2;
+        int flag = 1;
+        int count = 1;
+        int move = 0;
+        x: while (x != 0 || y != 0) {
+            for (int i = 0; i < 2; i++) {
+                move %= 4;
+                for (int j = 0; j < flag; j++) {
+                    x += dx[move];
+                    y += dy[move];
+                    if (x < 0 || x >= N || y < 0 || y >= N)
+                        break x;
+                    snail[x][y] = count++;
+                }
+                move++;
+            }
+            flag++;
+        }
+    }
+
+    static void blizzard(int dir, int count) {
+        int x = N / 2;
+        int y = N / 2;
+        while (count != 0) {
+            x += mdx[dir];
+            y += mdy[dir];
+            board[x][y] = 0;
+            count--;
+        }
+    }
+
+    // 미는 거를 구슬 change하는 것처럼 0만 뺴고 담기
+    static void pushReady() {
+        marbles = new ArrayList<>();
+        int x = N / 2;
+        int y = N / 2;
+        int flag = 1;
+        int move = 0;
+        x: while (x != 0 || y != 0) {
+            for (int i = 0; i < 2; i++) {
+                move %= 4;
+                for (int j = 0; j < flag; j++) {
+                    x += dx[move];
+                    y += dy[move];
+                    if (x < 0 || x >= N || y < 0 || y >= N)
+                        break x;
+                    if (board[x][y] != 0)
+                        marbles.add(board[x][y]);
+                }
+                move++;
+            }
+            flag++;
+        }
+    }
+
+    //
+    static void pop() {
+        marbles.add(0);
+        ArrayList<Integer> copied = new ArrayList<>();
+        int n = marbles.size();
+        int num = marbles.get(0);
+        boolean visited[] = new boolean[n];
+        int count = 1;
+        for (int i = 1; i < n; i++) {
+            if (num == marbles.get(i)) {
+                count++;
+            } else if (num != marbles.get(i)) {
+                if (count >= 4) {
+                    for (int j = i - 1; j > i - 1 - count; j--)
+                        visited[j] = true;
+                    popCount++;
+                    ans += count * num;
+                }
+                count = 1;
+                num = marbles.get(i);
+            }
+        }
+        for (int i = 0; i < n - 1; i++) {
+            if (!visited[i])
+                copied.add(marbles.get(i));
+        }
+        marbles = copied;
+    }
+
+    static void changeReady() {
+        marbles.add(0);
+        ArrayList<Integer> copied = new ArrayList<>();
+        int n = marbles.size();
+        int num = marbles.get(0);
+        int count = 1;
+        for (int i = 1; i < n; i++) {
+            if (num == marbles.get(i)) {
+                count++;
+            } else if (num != marbles.get(i)) {
+                copied.add(count);
+                copied.add(num);
+                count = 1;
+                num = marbles.get(i);
+            }
+        }
+        marbles = copied;
+    }
+
+    static void change() {
+        board = new int[N][N];
+        int x = N / 2;
+        int y = N / 2;
+        int flag = 1;
+        int move = 0;
+        int index = 0;
+        int indexM = marbles.size();
+        x: while (x != 0 || y != 0) {
+            for (int i = 0; i < 2; i++) {
+                move %= 4;
+                for (int j = 0; j < flag; j++) {
+                    x += dx[move];
+                    y += dy[move];
+                    if (x < 0 || x >= N || y < 0 || y >= N || index == indexM)
+                        break x;
+                    board[x][y] = marbles.get(index++);
+                }
+                move++;
+            }
+            flag++;
+        }
+    }
+}

--- a/김준엽/20231017/상어중학교.java
+++ b/김준엽/20231017/상어중학교.java
@@ -1,0 +1,183 @@
+import java.io.*;
+import java.util.*;
+
+public class 상어중학교 {
+    static int N, M;
+    static int board[][], dx[] = { -1, 1, 0, 0 }, dy[] = { 0, 0, -1, 1 };
+    static boolean visited[][], copied[][], ans[][];
+    static int maxBlock = 0, maxRainbow = 0, pos_x = -1, pos_y = -1;
+    static int score;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        board = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                board[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        while (true) {
+            visited = new boolean[N][N];
+            maxBlock = 0;
+            maxRainbow = 0;
+            pos_x = -1;
+            pos_y = -1;
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < N; j++) {
+                    if (board[i][j] > 0 && !visited[i][j]) {
+                        findBlock(i, j);
+                    }
+                }
+            }
+            if (maxBlock < 2)
+                break;
+            deleteBlock();
+            gravity();
+            rotate();
+            gravity();
+        }
+        System.out.println(score);
+    }
+
+    static void print() {
+        for (int i = 0; i < N; i++) {
+            System.out.print("[");
+            for (int j = 0; j < N; j++) {
+                if (board[i][j] == -2)
+                    System.out.print("  ");
+                else if (board[i][j] == -1)
+                    System.out.print("* ");
+                else
+                    System.out.print(board[i][j] + " ");
+            }
+            System.out.print("]");
+            System.out.println();
+        }
+        for (int i = 0; i < N; i++) {
+            System.out.println(Arrays.toString(visited[i]));
+        }
+        System.out.println();
+        System.out.println(maxBlock);
+        System.out.println();
+    }
+
+    static void findBlock(int x, int y) {
+        int rainbow = 0;
+        int block = 1;
+        int standard = board[x][y];
+        ArrayDeque<int[]> q = new ArrayDeque<>();
+        q.add(new int[] { x, y });
+        copied = new boolean[N][N];
+        visited[x][y] = true;
+        copied[x][y] = true;
+        while (!q.isEmpty()) {
+            int cur[] = q.poll();
+            for (int i = 0; i < 4; i++) {
+                int nx = cur[0] + dx[i];
+                int ny = cur[1] + dy[i];
+                if (0 > nx || nx >= N || 0 > ny || ny >= N)
+                    continue;
+                if (!visited[nx][ny]) {
+                    if (board[nx][ny] == standard) {
+                        block++;
+                        visited[nx][ny] = true;
+                        copied[nx][ny] = true;
+                        q.add(new int[] { nx, ny });
+                    } else if (board[nx][ny] == 0) {
+                        block++;
+                        rainbow++;
+                        visited[nx][ny] = true;
+                        copied[nx][ny] = true;
+                        q.add(new int[] { nx, ny });
+                    }
+                }
+            }
+        }
+        if (block == 1)
+            visited[x][y] = false;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (board[i][j] == 0)
+                    visited[i][j] = false;
+            }
+        }
+
+        if (block > maxBlock) {
+            maxBlock = block;
+            maxRainbow = rainbow;
+            pos_x = x;
+            pos_y = y;
+            ans = copied;
+        } else if (block == maxBlock) {
+            if (rainbow > maxRainbow) {
+                maxBlock = block;
+                maxRainbow = rainbow;
+                pos_x = x;
+                pos_y = y;
+                ans = copied;
+            } else if (rainbow == maxRainbow) {
+                if (x > pos_x) {
+                    maxBlock = block;
+                    maxRainbow = rainbow;
+                    pos_x = x;
+                    pos_y = y;
+                    ans = copied;
+                } else if (pos_x == x) {
+                    if (y > pos_y) {
+                        maxBlock = block;
+                        maxRainbow = rainbow;
+                        pos_x = x;
+                        pos_y = y;
+                        ans = copied;
+                    }
+                }
+            }
+        }
+    }
+
+    static void deleteBlock() {
+        int count = 0;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (ans[i][j]) {
+                    board[i][j] = -2;
+                    count++;
+                }
+            }
+        }
+        score += (int) Math.pow((double) count, (double) 2);
+    }
+
+    static void rotate() {
+        int copy[][] = new int[N][N];
+        int x = 0, y = 0;
+        for (int j = N - 1; j >= 0; j--) {
+            for (int i = 0; i < N; i++) {
+                copy[x][y++] = board[i][j];
+            }
+            x++;
+            y = 0;
+        }
+        board = copy;
+    }
+
+    static void gravity() {
+        for (int i = N - 2; i >= 0; i--) {
+            for (int j = 0; j < N; j++) {
+                int cur = i;
+                if (board[cur][j] == -1)
+                    continue;
+                while (cur != N - 1 && board[cur + 1][j] == -2) {
+                    board[cur + 1][j] = board[cur][j];
+                    board[cur][j] = -2;
+                    cur++;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 상어중학교
조건이 까다로운 BFS로 구역을 나누는 문제였습니다.
- `|r1 - r2| + |c1 - c2| = 1` 상하좌우에 인접해야합니다. 
- `무지개 블록`은 중복하여 포함이 가능하다.
- `기준블록`은 행과 열이 가장 작은 블록이다. (이는 왼쪽부터 오른쪽으로, 위에서 아래로 블록의 구역을 나누어야 한다는 소리로 이해했습니다.)
- -1 블록은 중력의 영향을 받지 않는다.
## 주의할 점
1. 최대 블럭을 찾는 과정에서는 rainbow 블럭과 일반 블럭을 따로 계산하여 중첩 if문으로 나누어 주었습니다.
2. 그런데 블럭을 찾는 과정에서 매번 visited 배열을 초기화해주고 새롭게 탐색을 해야한다고 생각했지만 그 과정에서 반례가 발생하였고, 기준의 블럭의 조각을 찾는 visited 배열은 그대로 사용해야 합니다.
3. 
즉 무지개블럭은 재사용이 가능하므로, 무지개 블럭의 경우 블럭 구역을 나누고 카운팅 한 후에 다시 방문할수 있게 `visited = false;`로 바꾸는 작업이 필요합니다.

# 마법사상어와 블리자드
달팽이 배열을 사용하는 문제입니다. (너무 싫어요)
- 대부분의 탐색을 달팽이 모양으로 진행하며 연속한 구슬을 체크한다.
- N은 홀수이므로 (N/2, N/2)가 중앙이다.
- 블리자드 마법 방향과 달팽이의 방향 전환 배열이 다르다(상하좌우 vs 좌하우상)
- 블리자드 마법의 범위는 배열 바깥으로 나가는 경우가 없다.
## 주의할 점
처음에는 달팽이 2차원 배열을 순서대로 탐색하는 snail이라는 N*N 배열을 두고 이를 이용하여 탐색을 하였으나 시간초과가 났습니다.
=>
그래서 달팽이 모양 순서대로 처음에 탐색을 하여 1차원 ArrayList로 만들어준 뒤 여러 작업들을 해준 뒤 다시 달팽이 모양으로 만드는 방식으로 진행하였습니다.

