### PR TITLE
[한태희] 1017 상어중학교, 마법사 상어와 블리자드

### DIFF
--- a/한태희/1017/Main_bj_g1_21611_마법사_상어와_블리자드.java
+++ b/한태희/1017/Main_bj_g1_21611_마법사_상어와_블리자드.java
@@ -1,6 +1,29 @@
 import java.util.*;
 import java.io.*;
 
+/*
+다 풀어놓고도 도대체 내가 뭘 푼건지 모르겠는 문제
+
+문제의 입력은 2차원 배열로 주어지지만, 문제 속 블록들의 작동들은 좌하우상 순서로 골뱅이처럼 돌아가는 1차원 배열의 형태를 띄고 있음을 알 수 있음.
+contvert 함수에서 2차원 배열을 회오리 순서대로 1차원 배열로 변환함.
+여기서 만들어진 배열은 inx:0이 중앙 위치이며, 그 뒤 순서대로 회오리 위치가 됨.
+
+블리자드 마법을 구현하기 위해서 1차원 배열에서의 위치를 표현하는 점화식을 찾음.
+블리자드 함수에는 상하좌우 방향과 최종거리 s가 주어짐.
+현재 위치가 pos, 나아간 칸이 d라고 하면 (1<=d<=s)
+위쪽:     pos(d) = pos(d-1) + 8*(d-1) + 7
+아래쪽:   pos(d) = pos(d-1) + 8*(d-1) + 3
+왼쪽:     pos(d) = pos(d-1) + 8*(d-1) + 1
+오른쪽:   pos(d) = pos(d-1) + 8*(d-1) + 5
+(초기조건으로, pos(0) = 0)
+
+move 함수는 배열 밀기로 간단하게 구현
+
+explode 함수는 4이상의 크기를 가진 그룹을 찾아 값을 0으로 만들고, bleed 함수는 문제에 나와있는 조건대로 (그룹 크기, 그룹원의 숫자)로 그룹을 변환함.
+사실 이 두개는 그룹 만드는 함수를 하나로 합쳐서 더 간단하게 구현 가능할것 같긴 함.
+
+ */
+
 public class Main_bj_g1_21611_마법사_상어와_블리자드 {
 	static int[] arr;
 	static int ans;
@@ -31,10 +54,6 @@ public class Main_bj_g1_21611_마법사_상어와_블리자드 {
 			while (explode()) {
 			}
 			breed();
-			System.out.println();
-			System.out.println((m + 1) + "번째 블리자드 후");
-			System.out.println(Arrays.toString(arr));
-			System.out.println();
 		}
 
 		System.out.println(ans);
@@ -93,8 +112,6 @@ public class Main_bj_g1_21611_마법사_상어와_블리자드 {
 			point += 8 * d + k;
 			arr[point] = 0;
 		}
-		System.out.println("블리자드");
-		System.out.println(Arrays.toString(arr));
 		move();
 		return arr;
 	}
@@ -108,8 +125,6 @@ public class Main_bj_g1_21611_마법사_상어와_블리자드 {
 			}
 		}
 		arr = ret;
-		System.out.println("밀어내기");
-		System.out.println(Arrays.toString(arr));
 	}
 
 	static boolean explode() {
@@ -144,8 +159,6 @@ public class Main_bj_g1_21611_마법사_상어와_블리자드 {
 			}
 		}
 
-		System.out.println("폭발");
-		System.out.println(Arrays.toString(arr));
 		move();
 		return ret;
 	}
@@ -186,7 +199,5 @@ public class Main_bj_g1_21611_마법사_상어와_블리자드 {
 			ret[i] = temp[i];
 		}
 		arr = ret;
-		System.out.println("증식");
-		System.out.println(Arrays.toString(arr));
 	}
 }

--- a/한태희/1017/Main_bj_g1_21611_마법사_상어와_블리자드.java
+++ b/한태희/1017/Main_bj_g1_21611_마법사_상어와_블리자드.java
@@ -1,0 +1,192 @@
+import java.util.*;
+import java.io.*;
+
+public class Main_bj_g1_21611_마법사_상어와_블리자드 {
+	static int[] arr;
+	static int ans;
+
+	public static void main(String args[]) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+
+		int[][] temp = new int[N][N];
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < N; j++) {
+				temp[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+
+		convert(temp);
+
+		ans = 0;
+
+		for (int m = 0; m < M; m++) {
+			st = new StringTokenizer(br.readLine());
+			int d = Integer.parseInt(st.nextToken());
+			int s = Integer.parseInt(st.nextToken());
+			blizard(temp.length, d, s);
+			while (explode()) {
+			}
+			breed();
+			System.out.println();
+			System.out.println((m + 1) + "번째 블리자드 후");
+			System.out.println(Arrays.toString(arr));
+			System.out.println();
+		}
+
+		System.out.println(ans);
+
+		br.close();
+	}
+
+	private static void convert(int[][] temp) {
+		int N = temp.length;
+		int r = N / 2;
+		int c = N / 2;
+
+		int[] dr = { 1, 0, -1, 0 };
+		int[] dc = { 0, 1, 0, -1 };
+
+		arr = new int[N * N];
+		int p = 0;
+		for (int d = 1; d <= N / 2; d++) {
+			r += dr[3];
+			c += dc[3];
+			p++;
+			arr[p] = temp[r][c];
+
+			for (int i = 0; i < 2 * d - 1; i++) {
+				r += dr[0];
+				c += dc[0];
+				p++;
+				arr[p] = temp[r][c];
+			}
+
+			for (int k = 1; k < 4; k++) {
+				for (int i = 0; i < 2 * d; i++) {
+					r += dr[k];
+					c += dc[k];
+					p++;
+					arr[p] = temp[r][c];
+				}
+			}
+		}
+	}
+
+	static int[] blizard(int N, int dir, int s) {
+		int point = 0;
+		int k = -1;
+		if (dir == 1) {
+			k = 7;
+		} else if (dir == 2) {
+			k = 3;
+		} else if (dir == 3) {
+			k = 1;
+		} else if (dir == 4) {
+			k = 5;
+		}
+
+		for (int d = 0; d < s; d++) {
+			point += 8 * d + k;
+			arr[point] = 0;
+		}
+		System.out.println("블리자드");
+		System.out.println(Arrays.toString(arr));
+		move();
+		return arr;
+	}
+
+	static void move() {
+		int[] ret = new int[arr.length];
+		int p = 1;
+		for (int i = 1; i < arr.length; i++) {
+			if (arr[i] != 0) {
+				ret[p++] = arr[i];
+			}
+		}
+		arr = ret;
+		System.out.println("밀어내기");
+		System.out.println(Arrays.toString(arr));
+	}
+
+	static boolean explode() {
+		boolean ret = false;
+		int startP = 1;
+		int endP = 1;
+		int gsize = 1;
+
+		if (arr[startP] == 0) {
+			return ret;
+		}
+
+		while (true) {
+			endP++;
+			if (endP == arr.length) {
+				break;
+			} else if (arr[startP] == arr[endP]) {
+				gsize++;
+			} else {
+				if (gsize >= 4) {
+					ret = true;
+					ans += arr[startP] * gsize;
+					for (int i = startP; i < endP; i++) {
+						arr[i] = 0;
+					}
+				}
+				if (arr[endP] == 0) {
+					break;
+				}
+				startP = endP;
+				gsize = 1;
+			}
+		}
+
+		System.out.println("폭발");
+		System.out.println(Arrays.toString(arr));
+		move();
+		return ret;
+	}
+
+	static void breed() {
+		int[] temp = new int[arr.length * 2];
+		int startP = 1;
+		int endP = 1;
+		int gsize = 1;
+		int wp = 1;
+
+		if (arr[startP] == 0) {
+			return;
+		}
+
+		while (true) {
+			endP++;
+			boolean cond1 = endP == arr.length || arr[endP] == 0;
+			boolean cond2 = false;
+			if (cond1 == false) {
+				cond2 = arr[startP] != arr[endP];
+			}
+			if (cond1 || cond2) {
+				temp[wp++] = gsize;
+				temp[wp++] = arr[startP];
+				if (cond1) {
+					break;
+				}
+				startP = endP;
+				gsize = 1;
+
+			} else {
+				gsize++;
+			}
+		}
+		int[] ret = new int[arr.length];
+		for (int i = 0; i < arr.length; i++) {
+			ret[i] = temp[i];
+		}
+		arr = ret;
+		System.out.println("증식");
+		System.out.println(Arrays.toString(arr));
+	}
+}

--- a/한태희/1017/Main_bj_g2_21609_상어_중학교.java
+++ b/한태희/1017/Main_bj_g2_21609_상어_중학교.java
@@ -1,0 +1,197 @@
+import java.util.*;
+import java.io.*;
+
+/*
+구현의 끝판왕 문제
+난해한 알고리즘은 없이 문제에 주어진 상황을 그대로 구현하면 되지만,
+그 구현양이 매우 많은 것이 문제다.
+
+무지개 블록이 아닌 일반 블록 중 대표 블록 선정: PQ를 이용하여 정렬
+각 블록이 묶여있는 집합 :Group Class를 작성. Group Class에 Comparable 인터페이스를 정의한다.
+Group 클래스는 문제에 주어진 대로 정렬되며 정령은 PQ를 이용하여 달성한다.
+=> 결론, PQ 2개 사용
+
+그룹 탐색에서 v 와 local_v의 두개의 visited 배열 사용.
+<용어: 일반 블록 -> 값 1 이상의 블록 (무지개 블록이 아닌 삭제 가능한 블록)>
+v배열: 일반블록에만 방문 체크 된다. 일반블록은 오로지 하나의 그룹에만 속하므로, 일반 블록이 중복되는 그룹에 속하지 않도록 막는 역할을 한다.
+local_v배열: 하나의 그룹을 탐색하는 과정에서 생성되고, 삭제된다. 한번의 그룹 탐색에서 한번 탐색한 위치는 다시는 들어가지 않도록 하는 역할을 한다.
+
+-2는 임의로 비어있는 위치에 대한 정보로 정의하였다.
+
+이 문제에서 가장 어려웠던 부분은 중력에 의해 블록이 떨어지는 함수인 gravity() 였다.
+현재 탐색 위치와 별개로 현재 탐색 위치의 블록이 떨어져야 하는 위치를 나타내는 변수인 t를 이용하여 구현했다.
+t는 블록이 떨어질때만 증가하고, 만약 탐색 위치 i가 금강불괴 블록(-1블록)이나 끝 위치를 만나면 i+1이상 t이하의 위치를 모두 -2 (비어있는 공간)으로 채운다.
+
+ */
+public class Main_bj_g2_21609_상어_중학교 {
+	static int N, M;
+	static int[][] arr;
+	static boolean[][] v;
+
+	static int[] dr = { -1, 1, 0, 0 };
+	static int[] dc = { 0, 0, -1, 1 };
+
+	static int score;
+
+	static class Group implements Comparable {
+		PriorityQueue<int[]> normalCords = new PriorityQueue<>(
+				(o1, o2) -> {
+					if (o1[0] == o2[0]) {
+						return Integer.compare(o1[1], o2[1]);
+					} else {
+						return Integer.compare(o1[0], o2[0]);
+					}
+				});
+		List<int[]> rainbowCords = new ArrayList<>();
+
+		public int compareTo(Object o) {
+			Group ohter = (Group) o;
+			if (this.size() == ohter.size()) {
+				if (this.rainbowCords.size() == ohter.rainbowCords.size()) {
+					if (this.normalCords.peek()[0] == ohter.normalCords.peek()[0]) {
+						return -Integer.compare(this.normalCords.peek()[1], ohter.normalCords.peek()[1]);
+					} else {
+						return -Integer.compare(this.normalCords.peek()[0], ohter.normalCords.peek()[0]);
+					}
+				} else {
+					return -Integer.compare(this.rainbowCords.size(), ohter.rainbowCords.size());
+				}
+			} else {
+				return -Integer.compare(this.size(), ohter.size());
+			}
+		}
+
+		int size() {
+			return this.normalCords.size() + this.rainbowCords.size();
+		}
+	}
+
+	public static void main(String args[]) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		arr = new int[N][N];
+
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < N; j++) {
+				arr[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+
+		score = 0;
+		while (true) {
+			PriorityQueue<Group> groups = getGroupPQ();
+			if (groups.size() == 0) {
+				break;
+			}
+			Group tg = groups.peek();
+			deleteTargetGroup(tg);
+			gravity();
+			rotate();
+			gravity();
+		}
+		System.out.println(score);
+
+		br.close();
+	}
+
+	static PriorityQueue<Group> getGroupPQ() {
+		v = new boolean[N][N];
+		PriorityQueue<Group> retPQ = new PriorityQueue<>();
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < N; j++) {
+				if (v[i][j]) {
+					continue;
+				} else if (arr[i][j] <= 0) {
+					continue;
+				}
+
+				Group group = makeGroup(new Group(), new boolean[N][N], arr[i][j], i, j);
+				if (group.size() > 1) {
+					retPQ.add(group);
+				}
+			}
+		}
+
+		return retPQ;
+	}
+
+	static Group makeGroup(Group g, boolean[][] local_v, int color, int r, int c) {
+		if (arr[r][c] != 0) {
+			g.normalCords.add(new int[] { r, c });
+			v[r][c] = true;
+		} else if (arr[r][c] == 0) {
+			g.rainbowCords.add(new int[] { r, c });
+
+		} else {
+			return g;
+		}
+		local_v[r][c] = true;
+
+		for (int k = 0; k < 4; k++) {
+			int nr = r + dr[k];
+			int nc = c + dc[k];
+			if (isValid(nr, nc) == false) {
+				continue;
+			}
+			if (local_v[nr][nc]) {
+				continue;
+			}
+			if (arr[nr][nc] == color || arr[nr][nc] == 0) {
+				makeGroup(g, local_v, color, nr, nc);
+			}
+		}
+
+		return g;
+	}
+
+	static void deleteTargetGroup(Group tg) {
+		List<int[]> tgCords = tg.rainbowCords;
+		tgCords.addAll(tg.normalCords);
+		for (int[] cord : tgCords) {
+			int r = cord[0];
+			int c = cord[1];
+			arr[r][c] = -2;
+		}
+		score += (tgCords.size() * tgCords.size());
+	}
+
+	static void gravity() {
+		for (int j = 0; j < N; j++) {
+			int t = N - 1;
+			for (int i = N - 1; i >= 0; i--) {
+				if (arr[i][j] != -2 && arr[i][j] != -1) {
+					arr[t--][j] = arr[i][j];
+				} else if (arr[i][j] == -1) {
+					for (int k = i + 1; k <= t; k++) {
+						arr[k][j] = -2;
+					}
+					t = i - 1;
+				}
+			}
+			for (int k = 0; k <= t; k++) {
+				arr[k][j] = -2;
+			}
+		}
+	}
+
+	static void rotate() {
+		int[][] temp = new int[N][N];
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < N; j++) {
+				temp[N - j - 1][i] = arr[i][j];
+			}
+		}
+		arr = temp;
+	}
+
+	static boolean isValid(int r, int c) {
+		if (0 <= r && r < N && 0 <= c && c < N) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
# 상어 중학교
난해한 알고리즘은 없이 문제에 주어진 상황을 그대로 구현하면 되지만,
그 구현양이 매우 많은 문제.

무지개 블록이 아닌 일반 블록 중 대표 블록 선정: PQ를 이용하여 정렬
각 블록이 묶여있는 집합 :Group Class를 작성. Group Class에 Comparable 인터페이스를 정의한다.
Group 클래스는 문제에 주어진 대로 정렬되며 정렬은 PQ를 이용하여 달성한다.
=> 결론, PQ 2개 사용

그룹 탐색에서 v 와 local_v의 두개의 visited 배열 사용.
<용어: 일반 블록 -> 값 1 이상의 블록 (무지개 블록이 아닌 삭제 가능한 블록)>
v배열: 일반블록에만 방문 체크 된다. 일반블록은 오로지 하나의 그룹에만 속하므로, 일반 블록이 중복되는 그룹에 속하지 않도록 막는 역할을 한다.
local_v배열: 하나의 그룹을 탐색하는 과정에서 생성되고, 삭제된다. 한번의 그룹 탐색에서 한번 탐색한 위치는 다시는 들어가지 않도록 하는 역할을 한다.

-2는 임의로 비어있는 위치에 대한 정보로 정의하였다.

이 문제에서 가장 어려웠던 부분은 중력에 의해 블록이 떨어지는 함수인 gravity() 였다.
현재 탐색 위치와 별개로 현재 탐색 위치의 블록이 떨어져야 하는 위치를 나타내는 변수인 t를 이용하여 구현했다.
t는 블록이 떨어질때만 증가하고, 만약 탐색 위치 i가 금강불괴 블록(-1블록)이나 끝 위치를 만나면 i+1이상 t이하의 위치를 모두 -2 (비어있는 공간)으로 채운다.

------
# 마법사 상어와 블리자드
다 풀어놓고도 도대체 내가 뭘 푼건지 모르겠는 문제

문제의 입력은 2차원 배열로 주어지지만, 문제 속 블록들의 작동들은 좌하우상 순서로 골뱅이처럼 돌아가는 1차원 배열의 형태를 띄고 있음을 알 수 있음.
contvert 함수에서 2차원 배열을 회오리 순서대로 1차원 배열로 변환함.
여기서 만들어진 배열은 inx:0이 중앙 위치이며, 그 뒤 순서대로 회오리 위치가 됨.

블리자드 마법을 구현하기 위해서 1차원 배열에서의 위치를 표현하는 점화식을 찾음.
블리자드 함수에는 상하좌우 방향과 최종거리 s가 주어짐.
현재 위치가 pos, 나아간 칸이 d라고 하면 (1<=d<=s)
위쪽:     pos(d) = pos(d-1) + 8*(d-1) + 7
아래쪽:   pos(d) = pos(d-1) + 8*(d-1) + 3
왼쪽:     pos(d) = pos(d-1) + 8*(d-1) + 1
오른쪽:   pos(d) = pos(d-1) + 8*(d-1) + 5
(초기조건으로, pos(0) = 0)

move 함수는 배열 밀기로 간단하게 구현

explode 함수는 크기가 4 이상인 그룹을 찾아서 값을 0으로 만들고, bleed 함수는 문제에 나와있는 조건대로 (그룹 크기, 그룹원의 숫자)로 그룹을 변환함.
사실 이 두개는 그룹 만드는 함수를 하나로 합쳐서 더 간단하게 구현 가능할것 같긴 함.