### PR TITLE
[전소영] 2310 4주차 (가장 먼 노드, 아이템 줍기)

### DIFF
--- a/전소영/2310w4/가장 먼 노드.java
+++ b/전소영/2310w4/가장 먼 노드.java
@@ -1,0 +1,55 @@
+import java.util.*;
+
+class Solution {
+
+    private class Node {
+        int num;
+        Node next;
+
+        Node(int num, Node next) {
+            this.num = num;
+            this.next = next;
+        }
+    }
+    public int solution(int n, int[][] edge) {
+
+        int max = 0;
+        int maxCnt = 0;
+        int[] dist = new int[n + 1];
+        Arrays.fill(dist, Integer.MAX_VALUE);
+        boolean[] visited = new boolean[n + 1];
+        Node[] adj = new Node[n + 1];
+        ArrayDeque<int[]> queue = new ArrayDeque<>();
+
+        for(int i = 0; i < edge.length; i++) {
+            int u = edge[i][0];
+            int v = edge[i][1];
+            adj[u] = new Node(v, adj[u]);
+            adj[v] = new Node(u, adj[v]);
+        }
+
+        visited[1] = true;
+        queue.add(new int[] {1, 0});
+        while(!queue.isEmpty()) {
+
+            int[] p = queue.poll();
+
+            dist[p[0]] = p[1];
+            if(max < p[1]) {
+                max = p[1];
+                maxCnt = 1;
+            }
+            else if(max == p[1]) {
+                maxCnt++;
+            }
+
+            for(Node node = adj[p[0]]; node != null; node = node.next) {
+                if(visited[node.num]) continue;
+                visited[node.num] = true;
+                queue.add(new int[] {node.num, p[1] + 1});
+            }
+        }
+
+        return maxCnt;
+    }
+}

--- a/전소영/2310w4/아이템 줍기.java
+++ b/전소영/2310w4/아이템 줍기.java
@@ -1,0 +1,68 @@
+import java.util.*;
+
+class Solution {
+    
+    static final int LEN = 51 * 2;
+    public int solution(int[][] rectangle, int characterX, int characterY, int itemX, int itemY) {
+        
+        characterX *= 2;
+        characterY *= 2;
+        itemX *= 2;
+        itemY *= 2;
+        
+        boolean[][] map = new boolean[LEN][LEN];
+        boolean[][] visited = new boolean[LEN][LEN];
+        int[] dx = {-1, 0, 1, 0};
+        int[] dy = {0, 1, 0, -1};
+        ArrayDeque<int[]> queue = new ArrayDeque<>();
+        
+        // 입력값 받아 직사각형 내부 true로 채우기
+        for(int i = 0; i < rectangle.length; i++) {
+            int x1 = rectangle[i][0] * 2;
+            int y1 = rectangle[i][1] * 2;
+            int x2 = rectangle[i][2] * 2;
+            int y2 = rectangle[i][3] * 2;
+            
+            for(int r = x1; r <= x2; r++) {
+                for(int c = y1; c <= y2; c++) {
+                    map[r][c] = true;
+                }
+            }
+        }
+        
+        // 경계선 남겨두고 false로 채우기
+        for(int i = 0; i < rectangle.length; i++) {
+            int x1 = rectangle[i][0] * 2 + 1;
+            int y1 = rectangle[i][1] * 2 + 1;
+            int x2 = rectangle[i][2] * 2 - 1;
+            int y2 = rectangle[i][3] * 2 - 1;
+            
+            for(int r = x1; r <= x2; r++) {
+                for(int c = y1; c <= y2; c++) {
+                    map[r][c] = false;
+                }
+            }
+        }
+        
+        // BFS 탐색하기
+        visited[characterX][characterY] = true;
+        queue.add(new int[] {characterX, characterY, 0});
+        
+        while(!queue.isEmpty()) {
+            
+            int[] xyd = queue.poll();
+            for(int d = 0; d < 4; d++) {
+                int xx = xyd[0] + dx[d];
+                int yy = xyd[1] + dy[d];
+                
+                if(xx == itemX && yy == itemY) return (xyd[2] + 1) / 2;
+                if(xx < 0 || xx >= LEN || yy < 0 ||  yy >= LEN || visited[xx][yy] || !map[xx][yy]) continue;
+                visited[xx][yy] = true;
+                queue.add(new int[] {xx, yy, xyd[2] + 1});
+            }
+        }
+        
+        return -1;
+    }
+
+}


### PR DESCRIPTION
# 가장 먼 노드
## 아이디어
간선의 길이는 없고, 모든 노드를 방문해서 1번 노드로부터의 거리를 구해야 한다.
BFS 탐색을 하자

## 풀이
1번에서부터 BFS 탐색
최댓값과 최댓값을 가지는 노드의 수는 `max`와 `maxCnt` 변수에 저장해서
거리가 max보다 커지면 두 값을 업데이트했다.

# 아이템 줍기
## 아이디어
이차원 배열에서 선분을 따라가야 하는 상황
`길이 1의 선분` ==  `1x1 크기의 한 칸의 변`인데, 구현하기 쉽도록
`길이 1의 선분` ==  `1x1 크기의 한 칸`으로 변환하자

즉, 전체 좌표를 2배로 확장해서 풀자

## 풀이
boolean[][] map으로 지도 선언 후,
1. 모든 직사각형 내부를 true로 표시
2. 직사각형마다 경계선을 제외한 내부를 false로 표시
3. 그럼 경계선만 true로 남는다

map[][]가 true인 곳에 대하여 출발지부터 도착지까지 BFS 탐색을 한다.
그리고 구한 길이 / 2 를 해서 답을 도출한다. (처음에 2배로 확장했기에)
