### PR TITLE
[김준엽] - 가장 먼 노드 && 아이템줍기

### DIFF
--- a/김준엽/20231023/가장먼노드.java
+++ b/김준엽/20231023/가장먼노드.java
@@ -1,0 +1,43 @@
+import java.util.*;
+class Solution {
+    static int visited[];
+    static int lines[][];
+    public int solution(int n, int[][] edge) {
+        int answer = 1;
+        int max = 0;
+        visited = new int[n+1];
+        lines = edge;
+        bfs();
+        for(int i=1; i<n+1; i++){
+            if(visited[i] > max){
+                answer = 1;
+                max = visited[i];
+            }
+            else if(visited[i] == max){
+                answer++;
+            }
+        }
+        System.out.println(Arrays.toString(visited));
+        return answer;
+    }
+    static void bfs(){
+        ArrayDeque<int []> q = new ArrayDeque<>();
+        visited[1] = 1;
+        q.add(new int []{1,1});
+        while(!q.isEmpty()){
+            int cur[] = q.poll();
+            int node = cur[0];
+            int count = cur[1];
+            for(int x[] : lines){
+                if(x[0] == node && visited[x[1]] == 0){
+                    visited[x[1]] = count+1;
+                    q.add(new int[] {x[1], count+1});
+                }
+                if(x[1] == node && visited[x[0]] == 0){
+                    visited[x[0]] = count+1;
+                    q.add(new int[] {x[0], count+1});
+                }
+            }
+        }
+    }
+}

--- a/김준엽/20231023/아이템줍기.java
+++ b/김준엽/20231023/아이템줍기.java
@@ -1,0 +1,53 @@
+import java.util.*;
+class Solution {
+    static int board[][];
+    static int N;
+    static int dx[]={-1,1,0,0}, dy[]={0,0,-1,1};
+    static int ix, iy;
+    static int ans;
+    public int solution(int[][] rectangle, int characterX, int characterY, int itemX, int itemY) {
+        board = new int[101][101];
+        ix = itemX;
+        iy = itemY;
+        int answer = 0;
+        for(int []rec : rectangle){
+            int x1 = rec[0]*2;
+            int y1 = rec[1]*2;
+            int x2 = rec[2]*2;
+            int y2 = rec[3]*2;
+            for(int i=x1; i<=x2; i++){
+                for(int j=y1; j<=y2; j++){
+                    if(board[i][j] ==2 )continue;
+                    board[i][j] = 2;
+                    if(i==x1 || i == x2 || j==y1 || j==y2){
+                        board[i][j] = 1;
+                    }
+                }
+            }
+        }
+        bfs(characterX*2,characterY*2);
+        return ans/2;
+    }
+    static void bfs(int x, int y){
+        boolean [][]visited=new boolean[101][101];
+        ArrayDeque<int[]> q = new ArrayDeque<>();
+        q.add(new int[]{x,y,0});
+        while(!q.isEmpty()){
+            int cur[]= q.poll();
+            if(cur[0] == ix*2 && cur[1] == iy*2){
+                ans =  cur[2];
+                return;
+            }
+            for(int i=0; i<4; i++){
+                int nx = cur[0] + dx[i];
+                int ny = cur[1] + dy[i];
+                if(nx < 0 || nx>100 || ny <0 || ny>100) continue;
+                if(!visited[nx][ny] && board[nx][ny] == 1){
+                    visited[nx][ny] = true;
+                    q.add(new int[] {nx, ny, cur[2] + 1});
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
# 가장 먼 노드
- DFS, BFS 모두 가능한 문제이며 단순 그래프 탐색으로도 풀리는 간단한 문제이다.
- 기준에 boolean으로 사용하던 visited 배열을 int 배열로 사용하여 방문 배열에 count를 넣어가며 모든 노드를 탐색하면 된다.
**visited  배열 중 가장 큰 값을 찾고, 해당과 값과 같은 값을 카운팅한 값이 정답이다.**

# 아이템 줍기
- 역시 아이템을 찾는 최단 거리를 찾아야 하므로 BFS를 사용하여 해당 아이템 좌표에 도착하면 return해주는 아이디어는 금방 떠올릴 수 있다.
- 하지만 사각형의 크기가 세로나, 가로 길이가 1일 경우에 테두리를 **행렬**인 배열로는 체크할 수가 없는 것을 알 수 있다.
- 여기서 떠올릴 수 있는 아이디어는 배열에 사각형을 표현하기 위해 가로, 세로 길이를 2배씩 증가시키면 된다.
=> 이러면 변의 길이가 1인 사각형도 테두리로 표현할 수 있다.
`좌표값을 모두 2배씩 늘리면 행렬 기준 테두리가 생기는 사각형을 표현할 수 있다.` 가 핵심 아이디어이다.
**2배씩 모든 크기를 증가시켰으므로, 정답도 2로 나누어주어야한다.**