### PR TITLE
[정성윤] 20231024 가장 먼 노드& 아이템 줍기

### DIFF
--- a/정성윤/20231024/가장 먼 노드.java
+++ b/정성윤/20231024/가장 먼 노드.java
@@ -1,0 +1,56 @@
+import java.util.*;
+
+class Solution {
+    public static ArrayList<Integer>[] al;
+    public static int N;
+    public static boolean[] visited;
+    public static int[] distance;
+    public static int ans=0,longest=0;
+    
+    public void dfs(int now,int dist){
+        for(int i=0;i<al[now].size();i++){
+            int next = al[now].get(i);   
+            if(next!=1){
+                if(distance[next] == 0 || distance[next] > dist+1){
+                    distance[next] = dist+1;
+                    dfs(next,dist+1);
+                    visited[next] = false;
+                }               
+            }         
+        }
+    }
+    
+    public int solution(int n, int[][] edge) {
+        int answer = 0;
+        N = n;
+        al = new ArrayList[N+1];
+        visited = new boolean[N+1];
+        distance = new int[N+1];
+        for(int i=0;i<N+1;i++){
+            al[i] = new ArrayList<>();
+        }
+        for(int[] ver : edge){
+            al[ver[0]].add(ver[1]);
+            al[ver[1]].add(ver[0]);
+        }
+
+        visited[1] = true;
+        dfs(1,0);
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+        for(int i=1;i<=N;i++){
+            pq.offer(distance[i]);
+        }
+        ans =  1;
+        longest = pq.poll();
+        while(!pq.isEmpty()){
+            if(longest != pq.poll()){
+                break;
+            }
+            else{
+                ans+=1;
+            }
+        }
+        answer = ans;
+        return answer;
+    }
+}

--- a/정성윤/20231024/아이템 줍기.java
+++ b/정성윤/20231024/아이템 줍기.java
@@ -1,0 +1,136 @@
+import java.util.*;
+
+class Solution {
+    public static int[][] xline;
+    public static int[][] yline;
+    public static int[][] board;
+    public static int[][] edge;
+    public static int N,M;
+    public static boolean[][] visited;
+    public static boolean[][] edgevisited;
+    
+    public static int[] di = {-1,0,1,0};
+    public static int[] dj = {0,1,0,-1};
+    
+    public static int ans = Integer.MAX_VALUE;
+    
+    public static void bfs(){
+        board[0][0] = 1;
+        ArrayDeque<int[]> ad = new ArrayDeque<>();
+        ad.offer(new int[]{0,0});
+        while(!ad.isEmpty()){
+            int[] now = ad.poll();
+            for(int d=0;d<4;d++){
+                int ni = now[0]+di[d];
+                int nj = now[1]+dj[d];
+                if(ni>=0 && ni<N && nj>=0 && nj<M && visited[ni][nj] == false){
+                    if(d==0 && xline[N-1-ni][nj] > 0){
+                        xline[N-1-ni][nj]++;
+                        continue;
+                    }
+                    else if(d== 1 && yline[nj][N-1-ni]>0){
+                        yline[nj][N-1-ni]++;
+                        continue;
+                    }
+                    else if(d== 2 && xline[N-1-now[0]][nj]>0){
+                        xline[N-1-now[0]][nj]++;
+                        continue;
+                    }
+                    else if(d== 3 && yline[now[1]][N-1-ni]>0){
+                        yline[now[1]][N-1-ni]++;
+                        continue;
+                    }
+                    else{
+                        board[ni][nj] = 1;
+                        visited[ni][nj] = true;
+                        ad.offer(new int[] {ni,nj});
+                    }  
+                }
+            }
+        }
+    }
+    
+    public static void dfs(int cx,int cy, int ix, int iy, int distance){
+        if(cx == ix && cy == iy){
+            edgevisited[iy][ix] = false;
+            ans = Math.min(ans,distance);
+            return;
+        }
+        
+        for(int d = 0; d<4;d++){
+            int ni = cy + di[d];
+            int nj = cx + dj[d];
+            if(ni>=0 && ni< N && nj>=0 && nj<M && edge[ni][nj] == 1 && edgevisited[ni][nj] == false){
+                int flag = 0;
+                if(d==0 && yline[cx][N-1-cy]==2){
+                    flag = 1;
+                }
+                else if(d==1 && xline[N-1-cy][cx]==2){
+                    flag = 1;
+                }
+                else if(d==2 && yline[cx][N-1-ni]==2){
+                    flag = 1;
+                }
+                else if(d==3 && xline[N-1-cy][nj]==2){
+                    flag = 1;
+                }
+                if (flag == 1){
+                    edgevisited[ni][nj] = true;
+                    dfs(nj,ni,ix,iy,distance+1);
+                }
+            }
+        }
+        return;
+    }
+    
+    public int solution(int[][] rectangle, int characterX, int characterY, int itemX, int itemY) {
+        int answer = 0;
+        int largex = 0;
+        int largey = 0;
+        for(int[] dot:rectangle){
+            largex = Math.max(largex,dot[2]);
+            largey = Math.max(largey,dot[3]);
+        }
+        N = largey+1;
+        M = largex+1;
+        board = new int[N][M];
+        edge = new int[N][M];
+        visited = new boolean[N][M];
+        edgevisited = new boolean[N][M];
+        xline = new int[N][M];
+        yline = new int[M][N];
+
+        for(int[] dot:rectangle){
+            int startx = dot[0];
+            int starty = dot[1];
+            int endx = dot[2];
+            int endy = dot[3];
+            
+            //board 저장용
+            for(int i=starty;i<endy;i++){
+                yline[startx][i] = 1;
+                yline[endx][i] = 1;
+            }
+            for(int i=startx;i<endx;i++){
+                xline[starty][i] = 1;
+                xline[endy][i] = 1;
+            }
+            //edge 저장용
+            for(int i= N-1-endy;i<=N-1-starty;i++){
+                edge[i][startx] = 1;
+                edge[i][endx] = 1;
+            }
+            for(int j=startx;j<=endx;j++){
+                edge[N-1-starty][j] = 1;
+                edge[N-1-endy][j] = 1;
+            }
+        }
+
+        bfs();
+        
+        edgevisited[N-1-characterY][characterX] = true;
+        dfs(characterX,N-1-characterY,itemX,N-1-itemY,0);
+        answer = ans;
+        return answer;
+    }
+}


### PR DESCRIPTION
# 가장 먼 노드
전형적인 dfs 문제입니다. 방문처리와 순회만 잘 처리해주면 간단한 문제였을거라 생각합니다.

## 풀이방법
1. dfs로 1번 노드로부터 모든 노드를 순회합니다.
2. 이때 싸이클이 발생할 수 있는 순회를 허용하되, 이미 저장된 경로가 순회하는 경로보다 길때만 순회를 진행합니다.
3. 위 방법으로 dfs를 돌리고 최댓값만 저장해두면 해결입니다.

# 아이템 줍기
엣지 디텍션에 대해 고민해 볼 수 있는 좋은 문제였다고 생각합니다.
수업 시간에 풀었던 "치즈" 문제와는 달리 엣지를 꼭짓점이 아닌 선으로 생각해줘야 합니다.
xline과 yline으로 나누어 고려해주었습니다.

## 풀이 방법
1. 주어진 점 정보에 따라 모든 점을 저장하고, 그 점을 잇는 선을 가로, 세로로 나눠 각각 xline, yline이라는 배열에 저장합니다.
2. 그 선을 기준으로, bfs를 돌때 진행 방향에 선이 존재하면 멈추는 방식으로 도형 내부와 외부를 구분합니다.
3. 이때 가장 외부의 선은 엣지로 따로 등록합니다.
4. 주어지는 캐릭터의 x,y좌표부터 목적지 아이템 x,y 좌표로 dfs를 진행하되, 진행 방향에 맞는 선이 엣지 선이 존재할 때만 진행합니다.
5. 이 방식으로 목적지로 가는 두 가지 경로 중 짧은 경로를 답으로 출력합니다.

## 주의할 점
문제에서 주어지는 조건은 y좌표가 아래쪽이 0입니다. 하지만 배열은 위쪽부터 0에서 카운팅 되기에, y 좌표를 잘 조정 해줘야 하는 부분인 은근히 까다로웠습니다.
