### PR TITLE
[전소영] 2310 5주차 (무인도 여행, 파괴되지 않은 건물) 

### DIFF
--- a/전소영/2310w5/무인도 여행.java
+++ b/전소영/2310w5/무인도 여행.java
@@ -1,0 +1,73 @@
+import java.util.*;
+
+class Solution {
+
+    static int n, m;
+    static int[][] map;
+    static boolean[][] visited;
+    static ArrayDeque<int[]> queue = new ArrayDeque<>();
+    static ArrayList<Integer> ans = new ArrayList<>();
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, 1, 0, -1};
+
+    public int[] solution(String[] maps) {
+
+        n = maps.length;
+        m = maps[0].length();
+        map = new int[n][m];
+        visited = new boolean[n][m];
+
+        for(int i = 0; i < n; i++) {
+            for(int j = 0; j < m; j++) {
+                char ch = maps[i].charAt(j);
+                if(ch != 'X') map[i][j] = ch - '0';
+            }
+        }
+
+        for(int i = 0; i < n; i++) {
+            for(int j = 0; j < m; j++) {
+                if(!visited[i][j] && map[i][j] > 0) {
+                    ans.add(bfs(i, j));
+                }
+            }
+        }
+
+        int[] answer = new int[ans.size()];
+        if(ans.size() == 0) {
+            answer = new int[] {-1};
+        }
+        else {
+            Collections.sort(ans);
+            for(int i = 0; i < ans.size(); i++) {
+            answer[i] = ans.get(i);
+            }
+        }
+
+        return answer;
+    }
+
+    private static int bfs(int x, int y) {
+
+        int sum = map[x][y];
+        visited[x][y] = true;
+        queue.add(new int[] {x, y});
+
+        while(!queue.isEmpty()) {
+
+            int[] xy = queue.poll();
+            for(int d = 0; d < 4; d++) {
+                int xx = xy[0] + dx[d];
+                int yy = xy[1] + dy[d];
+
+                if(xx < 0 || xx >= n || yy < 0 || yy >= m) continue;
+                if(!visited[xx][yy] && map[xx][yy] > 0) {
+                    sum += map[xx][yy];
+                    visited[xx][yy] = true;
+                    queue.add(new int[] {xx, yy});
+                }
+            }
+        }
+
+        return sum;
+    }
+}

--- a/전소영/2310w5/파괴되지 않은 건물.java
+++ b/전소영/2310w5/파괴되지 않은 건물.java
@@ -1,0 +1,44 @@
+class Solution {
+    public int solution(int[][] board, int[][] skill) {
+
+        int n = board.length;
+        int m = board[0].length;
+        int[][] sum = new int[n + 1][m + 1];
+
+        for(int i = 0; i < skill.length; i++) {
+            int cmd = skill[i][0] == 1 ? -1 : 1;
+            int x1 = skill[i][1];
+            int y1 = skill[i][2];
+            int x2 = skill[i][3];
+            int y2 = skill[i][4];
+            int v = skill[i][5];
+
+            sum[x1][y1] += cmd * v;
+            sum[x2 + 1][y2 + 1] += cmd * v;
+            sum[x1][y2 + 1] -= cmd * v;
+            sum[x2 + 1][y1] -= cmd * v;
+        }
+
+
+        for(int i = 0; i < n; i++) {
+            for(int j = 1; j < m; j++) {
+                 sum[i][j] += sum[i][j - 1];
+            }
+        }
+
+        for(int i = 1; i < n; i++) {
+            for(int j = 0; j < m; j++) {
+                 sum[i][j] += sum[i - 1][j];
+            }
+        }
+
+        int ans = 0;
+        for(int i = 0; i < n; i++) {
+            for(int j = 0; j < m; j++) {
+                if(board[i][j] + sum[i][j] > 0) ans++; 
+            }
+        } 
+
+        return ans;
+    }
+}


### PR DESCRIPTION
# 무인도 여행
BFS 탐색으로 연결된 칸들에 대해 합을 구한 후, arraylist에 넣은 다음 정렬하여 오름차순으로 출력했다.
(이런 문제는 pass...해도 될 듯 합니다..)

# 파괴되지 않은 건물
효율성을 만족하는 최적의 풀이는 고민하다 결국 인터넷 풀이를 참고해 풀었다.
누적 합을 2차원 배열로 확장하면 O(N)으로 해결할 수 있는 방식이다.
[2022 카카오 신입 공채 1차 온라인 코딩테스트 문제 해설](https://tech.kakao.com/2022/01/14/2022-kakao-recruitment-round-1/) 

## 누적 합이란? (Prefix Sum)
- 수열 An에 대하여 각 인덱스까지의 구간의 합을 구하는 것
- 시작점은 항상 첫번째 원소이고, R번째 원소까지의 합을 앞에서부터 쭉 더해오는 패턴
- 모든 구간에 대해 처음부터 계산하여 단순 반복하는 것이 아닌, 이전 인덱스까지의 누적 합에 현재 자기 자신 값을 더하여 구현하는 방식

## 예시
`[1, 2, 3, 4, 5]`로 이루어진 배열에서, 0번째부터 3번째 원소까지 2만큼을 빼서 `[-1, 0, 1, 2, 5]`을 구해보자
### 방법 1: 0번째부터 3번째 원소까지 반복문 사용
0번째 - `[-1, 2, 3, 4, 5]`
1번째 -`[-1, 0, 3, 4, 5]`
2번째 -`[-1, 0, 1, 4, 5]`
3번째 -`[-1, 0, 1, 2, 5]`
### 방법 2: 누적 합 배열 사용
`[-2, 0, 0, 0, 2]`를 저장한 새로운 배열 생성
앞에서부터 누적 합을 하면 `[-2, -2, -2, -2, 0]`이 됨
초기 배열 `[1, 2, 3, 4, 5]`와 더해줌
`[-1, 0, 1, 2, 5]`를 얻음
<br>
두번째 방법이 훨씬 효율적이다.
이를 2차원 배열로 확장해 보자

## 누적 합 2차원 확장
(0, 0)부터 (2, 2)까지 n만큼 변화시키자
```
n 0 0 -n
0 0 0 0
0 0 0 0
-n 0 0 n
```
이와 같이 새로운 배열을 만들고, 누적 합을 하면
```
n n n 0
n n n 0
n n n 0
0 0 0 0
```
의도한 만큼 변화를 줄 수 있음

## 풀이
그렇다면 2차원 누적 합 배열에 모든 공격, 회복에 대하여 n만큼의 변화를 담아두고
그 누적 합을 계산한 후
기존 배열과 합산하여 파괴되지 않은 건물의 수를 구하자

