### PR TITLE
[한태희] 1107 완료_ 등산코스 정하기 & 양과 늑대

### DIFF
--- a/한태희/1107/Solution_pgms_lv3_등산코스_정하기.java
+++ b/한태희/1107/Solution_pgms_lv3_등산코스_정하기.java
@@ -1,0 +1,147 @@
+import java.util.*;
+
+/*
+이분탐색
+
+다 풀고 나서 뭔가 찜찜해서 인터넷 검색해보니까 정석 풀이는 우선순위 큐를 이용한 bfs 탐색이 정석이더라고요..
+
+전 이분탐색이 보이면 써버리는 병에 걸려서 이분탐색으로 풀었습니다. (테케 중 일부는 3초 정도에 통과됨. 효율적이지는 않습니다.)
+
+풀이과정:
+
+1. 이분 탐색으로 1~K 사이의 연결 만으로 시작점에서 끝점까지 이동 가능한 최솟값 K를 찾는다.
+
+2. K를 구했으면, 1~K 사이의 연결 만으로 시작점에서 끝점까지 이동 가능한 경우 중, 1. intensity가 가장 작은 경우거나 2. intensity가 같으면 끝점의 번호가 가장 경우를 구한다.
+*/
+class Solution {
+    List<int[]>[] g;
+    boolean[] starts;
+    boolean[] ends;
+    int[] gates;
+    int N;
+    
+    public int[] solution(int n, int[][] paths, int[] local_gates, int[] summits) {
+        g = new List[n+1];
+        for(int i=1;i<n+1;i++){
+            g[i] = new ArrayList<>();
+        }
+        
+        for(int[] path:paths){
+            int x = path[0];
+            int y = path[1];
+            int d = path[2];
+            g[x].add(new int[]{y, d});
+            g[y].add(new int[]{x, d});
+        }
+        
+        ends = new boolean[n+1];
+        for(int p:summits){ends[p] = true;}
+        starts = new boolean[n+1];
+        for(int p:local_gates){starts[p] = true;}
+        
+        gates = local_gates;
+        N = n;
+        
+        int start = 1;
+        int end = 10000000;
+        int K=-1;
+        
+        while(start<=end){
+            
+            if(end-start==1){
+                if(check(start)){K = start;}
+                else{K = end;}
+                break;    
+            }
+            
+            int mid = (start+end)/2;
+            boolean poss = check(mid);
+            
+            if(poss==true){end = mid;}
+            else{start = mid;}
+        }
+        
+        return getAns(K);
+    }
+    
+    boolean check(int W){
+        for(int sp: gates){
+            boolean[] v = new boolean[N+1];
+            Queue<Integer> q = new ArrayDeque<>();
+            
+            q.add(sp);
+            v[sp] = true;
+            
+            while(q.isEmpty()==false){
+                int now = q.poll();
+                for(int[] data: g[now]){
+                    int next = data[0];
+                    int weight = data[1];
+                    
+                    if(v[next] || weight>W || starts[next]){
+                        continue;
+                    }
+                    if(ends[next]==true){
+                        return true;
+                    }
+                    
+                    v[next] = true;
+                    q.add(next);
+                }
+            }
+        }
+        
+        return false;
+    }
+    
+    int[] getAns(int W){
+        int[] ret = {Integer.MAX_VALUE, Integer.MAX_VALUE};
+        
+        for(int sp: gates){
+            boolean[] v = new boolean[N+1];
+            Queue<int[]> q = new ArrayDeque<>();
+            
+            q.add(new int[]{sp, 0});
+            v[sp] = true;
+            
+            while(q.isEmpty()==false){
+                int[] data1 = q.poll();
+                int now = data1[0];
+                int currw = data1[1];
+                for(int[] data2: g[now]){
+                    int next = data2[0];
+                    int weight = data2[1];
+                    
+                    if(v[next] || weight>W || starts[next]){
+                        continue;
+                    }
+                    
+                    if(currw < weight){
+                        currw = weight;
+                    }
+                    
+                    if(currw > ret[1]){
+                        continue;
+                    }
+                    
+                    if(ends[next]==true){
+                        if(currw < ret[1]){
+                            ret = new int[]{next, currw};
+                        }
+                        else if(currw==ret[1] && next < ret[0]){
+                            ret = new int[]{next, currw};
+                        }
+                        continue;
+                    }
+                    
+                    v[next] = true;
+                    q.add(new int[]{next, currw});
+                }
+            }
+        }
+        
+        return ret;
+    }
+    
+    
+}

--- a/한태희/1107/Solution_pgms_lv3_양과_늑대.java
+++ b/한태희/1107/Solution_pgms_lv3_양과_늑대.java
@@ -1,0 +1,92 @@
+import java.util.*;
+
+/*
+# 양과 늑대
+완전탐색 + 가지치기
+
+DP 같은 경우도 고민해 보았지만, 문제에서 주어진 상황대로 늑대가 양의 숫자를 넘으면 프루닝 하면서 완전 탐색을 하면 통과되었습니다. 
+
+이때, BFS를 이용해 구현했는데, 주의해야할 점은 하나의 노드를 방문하고, 다음으로 방문 가능한 경우는 그 노드의 자식 노드가 아니라, 이전에 방문 가능했던 노드들 + 이번에 방문한 노드의 자식 노드들 입니다.
+
+(다익스트라 알고리즘 처럼, 그래프 뭉텅이에서 탐색 가능한 다음 노드들을 모두 고려)
+
+class Solution {
+    
+    int[][] g;
+    int[] info;
+    int N;
+    int ans = 0;
+    
+    class Info{
+        int[] v; //0방문 안함 1:다음 목적지 2:방문함
+        int curr;
+        int point;
+    }
+    
+    public int solution(int[] local_info, int[][] edges) {
+        info = local_info;
+        N = info.length;
+        
+        g = new int[N][N];
+        for(int[] edge:edges){
+            g[edge[0]][edge[1]] = 1;
+        }
+        
+        Queue<Info> q = new ArrayDeque<>();
+        Info startinfo = new Info();
+        startinfo.v = new int[N];
+        startinfo.v[0] = 1;
+        startinfo.curr = 0;
+        startinfo.point = 0;
+        q.add(startinfo);
+        
+        //int cnt = 100;
+    
+        while(q.isEmpty()==false){
+            Info now = q.poll();
+            //cnt--;
+            //if(cnt==0) break;
+            //System.out.println(Arrays.toString(now.v));
+            //System.out.println(now.curr);
+            //System.out.println(now.point);
+            for(int i=0;i<N;i++){
+                if(now.v[i]==1){ //다음 방문 예정지라면
+                    Info next = new Info();
+                    next.v = deepcopy(now.v);
+                    next.v[i] = 2;
+                    for(int j=0;j<N;j++){
+                        if(g[i][j]==1){
+                            next.v[j] = 1;
+                        }
+                    }
+                    
+                    if(info[i]==0){
+                        next.curr = now.curr +1;
+                        next.point = now.point +1;
+                    }
+                    else{
+                        next.curr = now.curr -1;
+                        next.point = now.point;
+                    }
+                    
+                    if(ans < next.point){
+                        ans = next.point;
+                    }
+                    if(next.curr >0){
+                        q.add(next);
+                    }
+                }
+            }
+        }
+        
+        return ans;
+    }
+    
+    int[] deepcopy(int[] orig){
+        int[] ret = new int[orig.length];
+        for(int i=0;i<orig.length;i++){
+            ret[i] = orig[i];
+        }
+        return ret;
+    }
+}


### PR DESCRIPTION
# 등산코스 정하기
이분탐색

다 풀고 나서 뭔가 찜찜해서 인터넷 검색해보니까 정석 풀이는 우선순위 큐를 이용한 bfs 탐색이 정석이더라고요..

전 이분탐색이 보이면 써버리는 병에 걸려서 이분탐색으로 풀었습니다. (테케 중 일부는 3초 정도에 통과됨. 효율적이지는 않습니다.)

풀이과정:

1. 이분 탐색으로 1~K 사이의 연결 만으로 시작점에서 끝점까지 이동 가능한 최솟값 K를 찾는다.

2. K를 구했으면, 1~K 사이의 연결 만으로 시작점에서 끝점까지 이동 가능한 경우 중, 1. intensity가 가장 작은 경우거나 2. intensity가 같으면 끝점의 번호가 가장 경우를 구한다.

----
# 양과 늑대
완전탐색 + 가지치기

DP 같은 경우도 고민해 보았지만, 문제에서 주어진 상황대로 늑대가 양의 숫자를 넘으면 프루닝 하면서 완전 탐색을 하면 통과되었습니다. (노드 숫자가 적고 이진트리의 형태임으로, 가지치기와 함께라면 모든 경우의 수를 완탐이 가능할 것이라고 판단)

이때, BFS를 이용해 구현했는데, 주의해야할 점은 하나의 노드를 방문하고, 다음으로 방문 가능한 경우는 그 노드의 자식 노드가 아니라, 이전에 방문 가능했던 노드들 + 이번에 방문한 노드의 자식 노드들 입니다.

(다익스트라 알고리즘 처럼, 그래프 뭉텅이에서 탐색 가능한 다음 노드들을 모두 고려)