### PR TITLE
한태희 1114 (두 큐의 합 같게 만들기, 양궁대회) 완료

### DIFF
--- a/한태희/1114/Solution_pgms_lv2_두_큐_합_같게_만들기.java
+++ b/한태희/1114/Solution_pgms_lv2_두_큐_합_같게_만들기.java
@@ -1,0 +1,48 @@
+import java.util.*;
+
+/*
+두 큐의 합 구하기
+완전 탐색이나 DP같은 방법으로는 공간, 시간 복잡도를 절대 감당 못한다는 것은 문제 입력을 보고 바로 인지했습니다.
+
+빠르게 풀 수 있는 방법으로 그리디, 분할 정복, 구간합 등을 생각해보았습니다.
+
+그렇게 생각해보면서, 왠지 큐가 두개밖에 없어서 가장 연산 횟수가 적은 방법은 두 큐의 차이를 탐욕적으로 좁히는 방법일 것 같다는 직감이 들어서 손풀이를 해보니까 예제 테케가 맞았고, 그대로 코드로 제출하니까 통과됐습니다.
+
+결국 풀긴 풀었는데, 이게 왜 수학적으로 탐욕적 접근이 가능한지는 이해가 안된 상태입니다. 인터넷으로 검색해보니까 예상대로 구간합 풀이도 있더라고요.
+
+더 공부를 해야할 문제인것 같습니다.
+*/
+class Solution {
+    public int solution(int[] queue1, int[] queue2) {
+        Queue<Integer> q1 = new ArrayDeque<>();
+        Queue<Integer> q2 = new ArrayDeque<>();
+        long s1 = 0;
+        long s2 = 0;
+        int n = queue1.length;
+        for (int i = 0; i < n; i++) {
+            q1.add(queue1[i]);
+            s1 += queue1[i];
+            q2.add(queue2[i]);
+            s2 += queue2[i];
+        }
+
+        for (int t = 0; t <= 3 * n; t++) {
+            if (s1 == s2) {
+                return t;
+            } else if (s1 > s2) {
+                int k = q1.poll();
+                s1 -= k;
+                q2.offer(k);
+                s2 += k;
+            } else {
+                int k = q2.poll();
+                s2 -= k;
+                q1.offer(k);
+                s1 += k;
+            }
+        }
+
+        return -1;
+    }
+
+}

--- a/한태희/1114/Solution_pgms_lv2_양궁대회.java
+++ b/한태희/1114/Solution_pgms_lv2_양궁대회.java
@@ -1,0 +1,104 @@
+import java.util.*;
+
+/*
+양궁 대회
+
+쓸데없이 시선을 분산시키는 라이언 어피치가 있는 양궁과녁 사진이 제일 짜증나는 문제였습니다.
+
+처음엔 완탐을 고려해 보았지만, n이 커지면 11^n 꼴로 복잡도가 커질것 같아서 중단했습니다.
+
+'아니 이걸 탐색을 안하고 어떻게 풀지? DP나 이분탐색으로도 안되는데??' 라고 생각하며 테케를 자세히 보다 문제에서 함의하고 있는 방법대로 풀면 되는 탐색+구현문제라는 것을 깨달았습니다.
+
+이 문제에서 함의하고 있는 중요 사실은
+```
+라이언이 어피치를 제치고 점수 K를 얻기 위해선, K 과녁에 어피치보다 딱 한개 더 많은 화살을 꽂으면 된다.
+```
+입니다.
+
+따라서, 탐색의 분기는 라이언이 어피치보다 딱 하나 더 많은 화살을 꽂거나, 해당 점수는 깔끔하게 포기하거나 둘중 하나임을 알 수 있습니다.
+
+그리고, 문제에서도 밑줄이 쳐진 점수의 차가 동점일 경우에 대한 예외처리까지 하면 문제가 풀립니다.
+*/
+class Solution {
+    int N;
+    int[] ohter_info, ans_info, temp_info;
+    int max_diff = 0;
+
+    public int[] solution(int n, int[] info) {
+        N = n;
+        ohter_info = info;
+        ans_info = new int[11];
+        temp_info = new int[11];
+
+        if (ohter_info[10 - 10] < N) {
+            int K = ohter_info[10 - 10] + 1;
+            temp_info[10 - 10] += K;
+            N -= K;
+            search(10 - 1);
+            temp_info[10 - 10] -= K;
+            N += K;
+        }
+
+        search(10 - 1);
+
+        if (max_diff == 0) {
+            return new int[] { -1 };
+        } else {
+            return ans_info;
+        }
+    }
+
+    void search(int t) {
+        if (t == 0) {
+            temp_info[10 - 0] += N;
+            int x_sum = 0, y_sum = 0;
+            for (int i = 0; i < 11; i++) {
+                int x = temp_info[10 - i];
+                int y = ohter_info[10 - i];
+
+                if (x == 0 && y == 0) {
+                    continue;
+                } else if (x > y) {
+                    x_sum += i;
+                } else {
+                    y_sum += i;
+                }
+            }
+            int diff = x_sum - y_sum;
+            if (diff > max_diff || (diff == max_diff && checkChangeCond())) {
+                max_diff = diff;
+                ans_info = new int[11];
+                for (int i = 0; i < 11; i++) {
+                    ans_info[i] = temp_info[i];
+                }
+            }
+
+            temp_info[10 - 0] -= N;
+            return;
+        }
+
+        if (ohter_info[10 - t] < N) {
+            int K = ohter_info[10 - t] + 1;
+            temp_info[10 - t] += K;
+            N -= K;
+            search(t - 1);
+            temp_info[10 - t] -= K;
+            N += K;
+        }
+
+        search(t - 1);
+
+    }
+
+    boolean checkChangeCond() {
+        for (int i = 0; i < 11; i++) {
+            int x = temp_info[10 - i];
+            int y = ans_info[10 - i];
+            if (x > y)
+                return true;
+            else if (y > x)
+                return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
# 두 큐의 합 구하기

완전 탐색이나 DP같은 방법으로는 공간, 시간 복잡도를 절대 감당 못한다는 것은 문제 입력을 보고 바로 인지했습니다.

빠르게 풀 수 있는 방법으로 그리디, 분할 정복, 구간합 등을 생각해보았습니다.

그렇게 생각해보면서, 왠지 큐가 두개밖에 없어서 가장 연산 횟수가 적은 방법은 두 큐의 차이를 탐욕적으로 좁히는 방법일 것 같다는 직감이 들어서 손풀이를 해보니까 예제 테케가 맞았고, 그대로 코드로 제출하니까 통과됐습니다.

결국 풀긴 풀었는데, 이게 왜 수학적으로 탐욕적 접근이 가능한지는 직감적으로 느낌만 왔고, 엄밀하게 이해가 안된 상태입니다. 인터넷으로 검색해보니까 예상대로 구간합 풀이도 있더라고요.

더 공부를 해야할 문제인것 같습니다.

----

# 양궁 대회

쓸데없이 시선을 분산시키는 라이언 어피치가 있는 양궁과녁 사진이 제일 짜증나는 문제였습니다.

처음엔 완탐을 고려해 보았지만, n이 커지면 11^n 꼴로 복잡도가 커질것 같아서 중단했습니다.

'아니 이걸 탐색을 안하고 어떻게 풀지? DP나 이분탐색으로도 안되는데??' 라고 생각하며 테케를 자세히 보다 문제에서 함의하고 있는 방법대로 풀면 되는 탐색+구현문제라는 것을 깨달았습니다.

이 문제에서 함의하고 있는 중요 사실은
```
라이언이 어피치를 제치고 점수 K를 얻기 위해선, K 과녁에 어피치보다 딱 한개 더 많은 화살을 꽂으면 된다. 
그보다 화살을 더 꽂아도 점수가 늘어나지 않으니 아무런 의미가 없다.
반대로 그보다 화살을 덜 꽂으면 어차피 점수를 얻지 못하니 아예 화살을 투자하지 않으니만 못하다.
```
입니다.

따라서, 탐색의 분기는 라이언이 어피치보다 딱 하나 더 많은 화살을 꽂거나, 해당 점수는 깔끔하게 포기하거나 둘중 하나임을 알 수 있습니다.

그리고, 문제에서도 밑줄이 쳐진 점수의 차가 동점일 경우에 대한 예외처리까지 하면 문제가 풀립니다.