### PR TITLE
[김지현] 프로그래머스 두 수 합 같게 만들기, 양궁대회  #1114

### DIFF
--- a/김지현/1114/Solution_pro_두큐합같게만들기.java
+++ b/김지현/1114/Solution_pro_두큐합같게만들기.java
@@ -1,0 +1,54 @@
+import java.util.*;
+import java.io.*;
+
+class Solution {
+    
+    Queue<Integer> q1;
+    Queue<Integer> q2;
+    long sum, sum_q1;
+    int answer;
+    boolean flag;
+    
+    public int solution(int[] queue1, int[] queue2) {
+        int answer = 0;
+        int total_length = queue1.length + queue2.length;
+        // System.out.println("total length: "+total_length);
+        long sum_q2=0;
+        
+        q1 = new ArrayDeque<>();
+        q2 = new ArrayDeque<>();
+        
+        for(int i=0; i<queue1.length; i++){
+            q1.offer(queue1[i]);
+            sum_q1 += queue1[i];
+        }
+        for(int i=0; i<queue2.length; i++){
+            q2.offer(queue2[i]);
+            sum_q2 += queue2[i];
+        }
+        sum = sum_q1 + sum_q2;
+        if(sum % 2 == 1) return -1; // 총 합이 홀수라면 종료
+        
+        while(answer <= total_length*2 && !q1.isEmpty() && !q2.isEmpty()){
+            if(sum_q1 == sum/2){
+                return answer;
+            } else if (sum_q1 > sum/2){
+                int temp = q1.poll();
+                q2.offer(temp);
+                sum_q1 -= temp;
+                sum_q2 += temp;
+                answer++;
+            } else {
+                int temp = q2.poll();
+                q1.offer(temp);
+                sum_q1 += temp;
+                sum_q2 -= temp;
+                answer++;
+            }
+        }
+    
+        if(answer > total_length || sum_q1 != sum/2) return -1;
+
+        return answer;
+    }
+}

--- a/김지현/1114/Solution_pro_양궁대회.java
+++ b/김지현/1114/Solution_pro_양궁대회.java
@@ -1,0 +1,76 @@
+import java.util.*;
+import java.io.*;
+
+class Solution {
+    
+    int[] uppeach;
+    int N, gap=Integer.MIN_VALUE;
+    int[] answer;
+    
+    public int[] solution(int n, int[] info) {
+        answer = new int[11];
+        uppeach = info;
+        N = n;        
+        
+        dfs(0, 0, new int[11]);
+        
+        if(gap == Integer.MIN_VALUE) return new int[]{-1};
+        else return answer;
+    }
+    
+    public void cal(int[] lion){        
+        int sum_lion=0, sum_up=0;
+        for(int i=0; i<11; i++){
+            if(uppeach[i] > 0 && uppeach[i] >= lion[i]){
+                sum_up += (10-i);
+            } else if (lion[i] > 0) {
+                sum_lion += (10-i);
+            }
+        }
+        
+        if(sum_lion > sum_up && (sum_lion-sum_up) >= gap){
+            if((sum_lion - sum_up) == gap){
+                for(int i=10; i>=0; i--){
+                    if(lion[i] > 0 && answer[i] < lion[i]){
+                        // lion으로 갱신
+                        for(int j=0; j<11; j++){
+                            answer[j] = lion[j];
+                        }
+                    } else if(answer[i] > 0 && answer[i] > lion[i]){
+                        return;
+                    }
+                }
+            } else {
+                // lion으로 갱신
+                gap = sum_lion-sum_up;
+                for(int j=0; j<11; j++){
+                    answer[j] = lion[j];
+                }
+            }
+        }
+    }
+    
+    public void dfs(int idx, int sum, int[] lion){
+        if(idx == 11 || sum == N){
+            int tmp = 0;
+            for(int i=0; i<11; i++){
+                tmp += lion[i];
+            }
+            if(tmp < N){
+                lion[10] = (N-tmp);
+            } else if(tmp > N){
+                lion[10] = 0;
+            }
+            cal(lion);
+            return;
+        }
+        int up = uppeach[idx];
+        if(sum+(up+1) <= N){
+            lion[idx] = up+1;
+            dfs(idx+1, sum+=(up+1), lion); // 해당 점수 먹기
+            lion[idx] = 0;
+            sum -= (up+1);
+        }
+        dfs(idx+1, sum, lion); // 해당 점수 먹지 않기
+    }
+}


### PR DESCRIPTION
## 1. 두 수 합 같게 만들기
- 큐를 두 개를 쓰는 데, 각 큐의 원소 합을 같게 만들기 위한 작업의 최소 개수 리턴하기
- 한 큐에서 poll 한 원소를 다른 큐에 offer 하는 것 : **작업 1번**

### 아이디어
- 두 큐 원소의 합을 구해서 **홀수**라면 바로 종료(`-1 리턴`)
- 큐1 의 원소의 합이 `합/2` 과 같으면 되니, **큐 1개에만 집중**
- 큐1의 원소의 합이 합/2보다 **크면**, **큐1에서 빼서 큐2로 offer**
- 큐1의 원소의 합이 합/2보다 **작으면**, **큐2에서 빼서 큐1로 offer**
- 큐의 원소의 합을 구할때는, `poll한 큐 합 -= 뺀 원소 / offer한 큐 합 += 뺀 원소` 로 해야 시간초과가 나지 않는다.

계속 테스트케이스 1번에서 실패가 떠서, 찾아보니 총 카운트의 최댓값을 `두 큐의 길이 합` 으로 해놨는데, 반례가 있었다.
<img width="765" alt="스크린샷 2023-11-13 오후 7 54 42" src="https://github.com/SSAFY-Seoul-20-Study/Algorithm/assets/31675698/557eea5d-c7d6-4146-9cea-037a673b961d">
그래서, 총 카운트의 최대를 `두 큐의 길이 합 * 2` 로 해서 해결했다.

<hr>

## 2. 양궁대회
- 라이언이 가장 큰 점수 차이로 우승할 수 있는 방법이 여러 가지가 나올 수 있으므로, **`완전탐색`** 으로 구현했습니다.
- `dfs` 로 처음 인덱스부터 **`점수를 가져가는 것`**(어피치보다 +1)과 **`점수를 가져가지 않는 것`** 으로 재귀를 돌렸습니다.
- 나머지 부분은 문제에 있는대로 구현했습니다.