### PR TITLE
[김준엽] - 두 큐합 같게만들기 && 양궁대회

### DIFF
--- a/김준엽/20231024/가장먼노드.java
+++ b/김준엽/20231024/가장먼노드.java
@@ -1,0 +1,43 @@
+import java.util.*;
+class Solution {
+    static int visited[];
+    static int lines[][];
+    public int solution(int n, int[][] edge) {
+        int answer = 1;
+        int max = 0;
+        visited = new int[n+1];
+        lines = edge;
+        bfs();
+        for(int i=1; i<n+1; i++){
+            if(visited[i] > max){
+                answer = 1;
+                max = visited[i];
+            }
+            else if(visited[i] == max){
+                answer++;
+            }
+        }
+        System.out.println(Arrays.toString(visited));
+        return answer;
+    }
+    static void bfs(){
+        ArrayDeque<int []> q = new ArrayDeque<>();
+        visited[1] = 1;
+        q.add(new int []{1,1});
+        while(!q.isEmpty()){
+            int cur[] = q.poll();
+            int node = cur[0];
+            int count = cur[1];
+            for(int x[] : lines){
+                if(x[0] == node && visited[x[1]] == 0){
+                    visited[x[1]] = count+1;
+                    q.add(new int[] {x[1], count+1});
+                }
+                if(x[1] == node && visited[x[0]] == 0){
+                    visited[x[0]] = count+1;
+                    q.add(new int[] {x[0], count+1});
+                }
+            }
+        }
+    }
+}

--- a/김준엽/20231113/두큐합같게만들기.java
+++ b/김준엽/20231113/두큐합같게만들기.java
@@ -1,0 +1,35 @@
+import java.util.*;
+class Solution {
+    static int answer;
+    static ArrayDeque<Integer> q1 = new ArrayDeque<>();
+    static ArrayDeque<Integer> q2 = new ArrayDeque<>();
+    static long sum1, sum2;
+    public int solution(int[] queue1, int[] queue2) {
+        for(int i=0; i<queue1.length; i++){
+            q1.add(queue1[i]);
+            q2.add(queue2[i]);
+            sum1 += queue1[i];
+            sum2 += queue2[i];
+        }
+        while(!q1.isEmpty() && !q2.isEmpty()){
+            if(sum1 == sum2) return answer;
+            
+            if(sum1 > sum2){
+                int n1 = q1.poll();
+                sum1 -= n1;
+                sum2 += n1;
+                q2.add(n1);
+            }
+            else{
+                int n2 = q2.poll();
+                sum1 += n2;
+                sum2 -= n2;
+                q1.add(n2);
+            }
+            answer++;
+            if(answer >= 300000) break;
+        }
+        
+        return -1;
+    }
+}

--- a/김준엽/20231113/양궁대회.java
+++ b/김준엽/20231113/양궁대회.java
@@ -1,0 +1,44 @@
+import java.util.*;
+class Solution {
+    static int num[] = new int[11];
+    static int gInfo[];
+    static int answer[];
+    static int max = Integer.MIN_VALUE;;
+    public int[] solution(int n, int[] info) {
+        answer = new int[11];
+        comb(0, n, info);
+        if(max == -1) return new int[] {-1};
+        return answer;
+    }
+    
+    static void comb(int depth, int n, int info[]){
+        if(depth == n){
+            int flag = calScore(info);
+            if(max <= flag){
+                answer = num.clone();
+                max = flag;
+            }
+            return;
+        }
+        for(int i=0; i<num.length && num[i] <= info[i]; i++){
+            num[i] ++;
+            comb(depth+1, n, info);
+            num[i] --;
+        }
+    }
+    static int calScore(int gInfo[]){
+        int score1=0, score2=0;
+        for(int i=0; i<num.length; i++){
+            if(gInfo[i] == 0 && num[i] == 0) continue;
+            if(gInfo[i] >= num[i]){
+                score1 += (10-i);
+            }
+            else score2 += (10-i);
+        }
+
+        int diff = score2 - score1;
+        if(diff<=0) return -1;
+        return diff;
+    }
+   
+}


### PR DESCRIPTION
# 두 큐 합 같게만들기
-  그리디 알고리즘
- 자칫 보면 완탐?
두 큐의 합을 저장해두고, q1의 합이 크면 q1에서 값을 꺼내어 q2에 넣고 반대의 경우에는 반대로 시행하며 그리디지만 완탐스럽게 문제를 풀면 되었습니다.
결국 큐는 값이 나오는 곳은 앞부분 한 곳이고, 결국 큰곳에서 작은곳으로 옮겨야 하는 것은 어떤 경우이건 같기 때문에 종료조건만 찾아주면 되는 문제였습니다.

# 양궁 대회
- 완전 탐색 (브루트 포스)
- N = 10이고 총 점수의 개수는 11개이므로 아슬아슬하게 중복조합이 가능하다.
그래서 중복조합을 짜는데 가장 오랜시간이 걸렸던 문제입니다.
하지만 그냥 중복조합을 짜는 경우에는 시간초과가 나므로 인덱스가 작은 값이 점수가 큰 점을 이용해 `num.length && num[i]<= info[i]` 으로 중간에 가지치기를 해주어야 합니다.