### PR TITLE
[남수진 1114] 양궁대회, 두 큐 합 같게만들기

### DIFF
--- a/남수진/1114/pg_두큐합같게만들기.java
+++ b/남수진/1114/pg_두큐합같게만들기.java
@@ -1,0 +1,43 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int[] queue1, int[] queue2) {
+        int answer = 0;
+        
+        ArrayDeque<Integer> q1 = new ArrayDeque<>();
+        ArrayDeque<Integer> q2 = new ArrayDeque<>();
+        
+        long sum1 = 0, sum2 = 0;
+        for(int i = 0; i< queue1.length; i++) {
+            sum1 += queue1[i];
+            q1.offer(queue1[i]);
+        }
+        
+        for(int i = 0; i < queue2.length; i++) {
+            sum2 += queue2[i];
+            q2.offer(queue2[i]);
+        }
+        
+        
+        if((sum1 + sum2) % 2 != 0) return -1;
+        
+        while(true) {
+            if(sum1 == sum2) return answer;
+            if(answer > queue1.length + queue2.length) return -1;
+            
+            if(sum1 < sum2) {
+                int tmp = q2.poll();
+                sum1 += tmp;
+                sum2 -= tmp;
+                q1.offer(tmp);
+            } else {
+                int tmp = q1.poll();
+                sum1 -= tmp;
+                sum2 += tmp;
+                q2.offer(tmp);
+            }
+            answer++;
+        }
+        // return answer;
+    }
+}

--- a/남수진/1114/pg_두큐합같게만들기.java
+++ b/남수진/1114/pg_두큐합같게만들기.java
@@ -23,7 +23,7 @@ class Solution {
         
         while(true) {
             if(sum1 == sum2) return answer;
-            if(answer > queue1.length + queue2.length) return -1;
+            if(answer > queue1.length + queue2.length + 1) return -1;
             
             if(sum1 < sum2) {
                 int tmp = q2.poll();

--- a/남수진/1114/pg_양궁대회.java
+++ b/남수진/1114/pg_양궁대회.java
@@ -1,0 +1,68 @@
+import java.util.*;
+class Solution {
+    
+    static int[] answer, tmp;
+    static int max = 0, maxCnt = 0, minIdx = 0;
+    public int[] solution(int n, int[] info) {        
+        answer = new int[11];
+        tmp = new int[11];
+        
+        recur(n, 0, info);
+
+        if(max == 0) return new int[] {-1};
+        else return answer;
+    }
+    
+    static void recur(int cnt, int start, int[] info) {
+        if(cnt == 0) {
+            int sumA = 0, sumB = 0, count = 0, idx = 0;
+            for(int i = 0; i <= 10; i++) {
+                if(info[i] < tmp[i]) sumB += 10 - i;
+                else if(info[i] > tmp[i]) sumA += 10 - i;
+                if(tmp[i] != 0) {
+                    count = tmp[i];
+                    idx = 10 - i;
+                }
+            }
+            boolean flag = false;
+            
+            if(sumA < sumB) {
+                if(max < sumB - sumA) {
+                    minIdx = idx;
+                    maxCnt = count;
+                    max = sumB - sumA;
+                    flag = true;                   
+                } else if(max == sumB - sumA) {
+                    if(minIdx > idx) {
+                        minIdx = idx;
+                        maxCnt = count;
+                        flag = true;
+                    } else if(minIdx == idx && maxCnt < count) {
+                        maxCnt = count;
+                        flag = true;
+                    }
+                }
+            }
+            
+            if(flag) {
+                for(int i = 0; i <= 10; i++) {
+                    answer[i] = tmp[i];
+                }
+            }
+            return;
+        }
+        
+        for(int i = start; i <= 10; i++) {
+            if(i != 10) {
+                if(cnt < info[i] + 1) continue;
+                tmp[i] = info[i] + 1;
+                recur(cnt - tmp[i], i + 1, info);
+                tmp[i] = 0; 
+            } else {
+                tmp[i] = cnt;
+                recur(0, i + 1, info);
+                tmp[i] = 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 양궁대회
- 완전탐색
- 라이언이 가장 큰 점수 차로 이기는 경우 중, 점수가 낮은 화살 개수가 적은 경우의 수 찾기
- 조건 고려해서 결과 반환

# 두 큐 합 같게만들기
- 값이 많은 큐에서 값이 적은 큐로 poll, offer해서 두 큐의 값이 같게 되면 return
- 작업의 수가 두 큐의 합 + 1를 넘어가면 목표를 달성할 수 없으므로 return