### PR TITLE
[김지현] 2146 다리만들기, 10451 순열사이클 #240109

### DIFF
--- a/김지현/240109/Main_boj_10451_순열사이클.java
+++ b/김지현/240109/Main_boj_10451_순열사이클.java
@@ -1,0 +1,56 @@
+import java.util.*;
+import java.io.*;
+
+// 55268KB	560ms
+public class Main_boj_10451_순열사이클 {
+
+    static int N;
+    static int[] arr, parents;
+
+    public static void main(String[] args) throws Exception {
+//        System.setIn(new FileInputStream("res/input_boj_10451.txt"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int T = Integer.parseInt(br.readLine());
+        for(int t=0; t<T; t++){
+            N = Integer.parseInt(br.readLine());
+            arr = new int[N+1];
+            st = new StringTokenizer(br.readLine());
+            for(int i=1; i<=N; i++){
+                arr[i] = Integer.parseInt(st.nextToken());
+            }
+            // parents 초기화
+            parents = new int[N+1];
+            for(int i=1; i<=N; i++){
+                parents[i] = i;
+            }
+            System.out.println(find_cycle());
+        }
+    }
+
+    private static int find_cycle(){
+        for(int i=1; i<=N; i++){
+            union(i, arr[i]);
+        }
+
+        int cycle_count = 0;
+        for(int i=1; i<=N; i++){
+            if(i == parents[i]) cycle_count++;
+        }
+//        System.out.println(Arrays.toString(parents));
+        return cycle_count;
+    }
+
+    private static void union(int a, int b){
+        a = find(a);
+        b = find(b);
+        if(a > b) parents[a] = b;
+        else parents[b] = a;
+    }
+
+    private static int find(int x){
+        if(parents[x] == x) return parents[x];
+        return parents[x]=find(parents[x]);
+    }
+}

--- a/김지현/240109/Main_boj_2146_다리만들기.java
+++ b/김지현/240109/Main_boj_2146_다리만들기.java
@@ -1,0 +1,111 @@
+import java.util.*;
+import java.io.*;
+
+// 138324KB	296ms
+public class Main_boj_2146_다리만들기 {
+    static int N, min_res = 200;
+    static int[][] map;
+    static ArrayDeque<int[]> q = new ArrayDeque<>();
+    static boolean[][] v = new boolean[N][N];
+    static boolean[][] vv;
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, -1, 0, 1};
+
+    public static void main(String[] args) throws Exception {
+//        System.setIn(new FileInputStream("res/input_boj_2146.txt"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        map = new int[N][N];
+        for(int i=0; i<N; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j=0; j<N; j++){
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // 각 섬에 고유번호 부여
+        bfs_island_split();
+
+        // 다리 놓기
+        bridge();
+
+        System.out.println(min_res);
+    }
+
+    private static void bridge(){
+        v = new boolean[N][N];
+
+        for(int i=0; i<N; i++){
+            for(int j=0; j<N; j++){
+                if(map[i][j] > 0){
+                    v[i][j] = true;
+                    bfs_bridge(i, j, map[i][j]);
+                }
+            }
+        }
+    }
+
+    private static void bfs_bridge(int x, int y, int island_num){
+        q = new ArrayDeque<>();
+        vv = new boolean[N][N];
+
+        q.offer(new int[]{x, y, 0});
+        vv[x][y] = true;
+
+        while(!q.isEmpty()){
+            int[] now = q.poll();
+            for(int d=0; d<4; d++){
+                int nx = now[0] + dx[d];
+                int ny = now[1] + dy[d];
+                if(isRange(nx, ny) && !vv[nx][ny] && map[nx][ny] != island_num){
+                    if(map[nx][ny] == 0){
+                        q.offer(new int[]{nx, ny, now[2]+1});
+                        vv[nx][ny] = true;
+                    } else {
+                        min_res = Math.min(min_res, now[2]);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void bfs_island_split(){
+        int island_count = 0;
+        v = new boolean[N][N];
+
+        for(int i=0; i<N; i++){
+            for(int j=0; j<N; j++){
+                if(!v[i][j] && map[i][j] == 1){
+                    island_count++;
+                    bfs_island(i, j, island_count);
+                }
+            }
+        }
+    }
+    private static void bfs_island(int x, int y, int island_num){
+        q = new ArrayDeque<>();
+
+        q.offer(new int[]{x, y});
+        map[x][y] = island_num; // 이 코드 없으면, island 크기 1일 때, 체크가 안됨.
+        while(!q.isEmpty()) {
+            int[] now = q.poll();
+            for(int d=0; d<4; d++){
+                int nx = now[0] + dx[d];
+                int ny = now[1] + dy[d];
+                if(isRange(nx, ny) && map[nx][ny] == 1 && !v[nx][ny]){
+                    q.offer(new int[]{nx, ny});
+                    v[nx][ny] = true;
+                    map[nx][ny] = island_num;
+                }
+            }
+        }
+    }
+
+    private static boolean isRange(int x, int y){
+        if(0 <= x && x < N && 0 <= y && y < N) return true;
+        return false;
+    }
+}


### PR DESCRIPTION
## 2146 다리만들기(G3)
오랜만에 알고리즘을 풀어서, 꽤나 오래걸렸습니다..

**풀이방법**
1. 각 섬마다 고유번호를 준다. (BFS)
2. map 을 돌면서 섬이 있는 경우, 0을 따라가면서 개수를 센다(BFS)
3. 다른 번호의 섬을 만나면, 최소 다리수 갱신 후 바로 종료

이런 식으로 **BFS 2번** 돌려 풀었습니다.

처음 채점 시에 틀렸는데, 
이유는 섬에 고유번호를 줄 때, 1을 찾았을 때, 해당 위치에서 bfs로 같은 섬을 모두 같은 번호로 바꿔주었습니다. 
그러나, **섬의 크기가 1일 때**는 bfs 자체를 돌지 않기 때문에, 숫자가 바뀌지 않아, 같은 섬으로 인식되는 문제가 있었습니다.
그래서 1을 찾았을 때, 바로 섬 고유번호로 갱신해서 해결했습니다!

## 10451 순열사이클(S3)
**풀이방법**

`union-find 알고리즘`을 사용해서 풀었고, `인덱스(i) == parents[i]` 가 같은 개수를 세어 사이클 개수를 출력했습니다.
* parents[i] 를 Set 에 넣고, size 개수를 출력하는 방식도 가능합니다! (저는 사이클이 반드시 보장되지 않는 것으로 생각해서 인덱스와 같은 개수를 세었는데, `1 ~ N 개의 순열`인 것을 보아, 사이클이 반드시 보장됩니다!