### PR TITLE
[하동준] 2146 다리만들기,10451 순열사이클 #240109

### DIFF
--- a/하동준/240109/boj_10451_순열사이클.java
+++ b/하동준/240109/boj_10451_순열사이클.java
@@ -1,0 +1,82 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class boj_10451_순열사이클 {
+    static int n;
+    static int[] p;
+    static int[] g;
+    static boolean[] v;
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+        int t = Integer.parseInt(br.readLine());
+        for (int i = 0; i < t; i++) {
+            n = Integer.parseInt(br.readLine());
+            st = new StringTokenizer(br.readLine());
+            g = new int[n+1];
+            v = new boolean[n+1];
+            for (int j = 1; j <= n; j++) {
+                int to = Integer.parseInt(st.nextToken());
+                g[j] = to;
+            }
+            int cnt = 0;
+            make();
+            for (int j = 1; j <= n; j++) {
+//                System.out.printf("for문"+j+"입니다.\n");
+
+                // j에서 to
+                int from = j;
+                if (v[from]) continue;
+                int to = g[j];
+                v[from] = true;
+                while (true) {
+                    // 사이클 미발생 -> to 방문체크, to를 from으로 교체
+                    if (union(from,to)) {
+//                        System.out.printf("from: %d to: %d\n",from,to);
+//                        System.out.println(Arrays.toString(p));
+                        v[to] = true;
+                        from = to;
+                        to = g[from];
+                    } else {
+                        // 사이클 발생 -> cnt++, break
+//                        System.out.println("사이클 발생");
+//                        System.out.printf("from: %d to: %d\n",from,to);
+//                        System.out.println(Arrays.toString(p));
+                        cnt++;
+                        break;
+                    }
+//                    if (v[to]) break;
+                }
+            }
+//            System.out.println(cnt);
+            sb.append(cnt).append("\n");
+//            break;
+        }
+        System.out.println(sb.toString());
+    }
+    static boolean union(int a, int b) {
+        int aRoot = find(a);
+        int bRoot = find(b);
+        if (aRoot==bRoot) return false;
+        p[a] = bRoot;
+        return true;
+    }
+    static int find(int a) {
+        if (p[a]==a) return a;
+        return p[a]=find(p[a]);
+    }
+    static void make() {
+        p = new int[n+1];
+        for (int i = 1; i <= n; i++) {
+            p[i] = i;
+        }
+    }
+
+}

--- a/하동준/240109/boj_2146_다리만들기.java
+++ b/하동준/240109/boj_2146_다리만들기.java
@@ -1,0 +1,125 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class boj_2146_다리만들기 {
+    static int n,min=Integer.MAX_VALUE;
+    static int[][] move = {{-1,0},{0,1},{1,0},{0,-1}};
+    static int[][] board;
+    static boolean[][] v;
+    static ArrayList<int[]> path = new ArrayList<>();
+    static ArrayList<int[]> landEdges = new ArrayList<>();
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        board = new int[n][n];
+        v = new boolean[n][n];
+        StringTokenizer st;
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                board[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        int num = 1;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (board[i][j]>0 && !v[i][j]) {
+                    paint(i,j,num);
+                    num++;
+                }
+            }
+        }
+//        for (int i = 0; i < n; i++) {
+//            for (int j = 0; j < n; j++) {
+//                System.out.printf(board[i][j]+" ");
+//            }
+//            System.out.println();
+//        }
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                v[i][j] = false;
+                if (board[i][j]>0){
+                    boolean isEdge = false;
+                    for (int[] dxy:move) {
+                        int nx = i + dxy[0];
+                        int ny = j + dxy[1];
+                        if (0<=nx && nx<n && 0<=ny && ny<n && board[nx][ny]==0) {
+                            isEdge = true;
+                        }
+                    }
+                    if (isEdge) landEdges.add(new int[]{i,j});
+                }
+            }
+        }
+
+
+
+        for (int i = 0; i < landEdges.size(); i++) {
+            int x = landEdges.get(i)[0];
+            int y = landEdges.get(i)[1];
+            int landNum = board[x][y];
+//            path.clear();
+
+            ArrayDeque<int[]> q = new ArrayDeque<>();
+            q.offer(new int[]{x,y,0});
+//            path.add(new int[]{x,y,0});
+            v[x][y] = true;
+
+            while (!q.isEmpty()) {
+                int[] cur = q.poll();
+                if (board[cur[0]][cur[1]]>0 && board[cur[0]][cur[1]]!=landNum) {
+                    // 이동했는데 다른 섬 -> 갱신후 stop
+                    min = Math.min(min, cur[2]-1);
+                    break;
+                }
+                if (x!=cur[0] && y!=cur[1] && board[cur[0]][cur[1]]==landNum) {
+                    // 이동했는데 같은섬 -> 블록
+                    continue;
+                }
+                for (int[] dxy:move) {
+                    int nx = cur[0]+dxy[0];
+                    int ny = cur[1]+dxy[1];
+                    if (0<=nx && nx<n && 0<=ny && ny<n && !v[nx][ny]) {
+                        q.offer(new int[]{nx,ny,cur[2]+1});
+                        v[nx][ny] = true;
+//                        path.add(new int[]{nx,ny,cur[2]+1});
+                    }
+                }
+            }
+
+            for (int j = 0; j < n; j++) {
+                for (int k = 0; k < n; k++) {
+                    v[j][k] = false;
+                }
+            }
+        }
+//        for (int[] xy:path) {
+//            v[xy[0]][xy[1]] = false;
+//        }
+
+        System.out.println(min);
+
+    }
+    static void paint(int x, int y, int num){
+        ArrayDeque<int[]> q = new ArrayDeque<>();
+        q.offer(new int[]{x,y});
+        board[x][y] = num;
+        v[x][y] = true;
+        while (!q.isEmpty()) {
+            int[] cur = q.poll();
+            for (int[] dxy:move) {
+                int nx = cur[0]+dxy[0];
+                int ny = cur[1]+dxy[1];
+                if (0<=nx && nx<n && 0<=ny && ny<n && board[nx][ny]>0 && !v[nx][ny]){
+                    board[nx][ny] = num;
+                    v[nx][ny] = true;
+                    q.offer(new int[]{nx,ny});
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 2146 다리만들기(G3)

최적화를 제대로 못했어요.

풀이방법

1. 입력으로 받은 board(0/1)을 BFS를 돌며 섬의 번호로 바꾼다. (1,2,3,4)
2. 이중for문으로 각 칸의 4방중 바다 칸이 있으면 가장자리입니다. 가장자리 리스트를 받아놓아요.
3. 각 가장자리칸에서 연속으로 4방 BFS 탐색합니다. 이때 큐에는 좌표와 이동횟수를 넣어요.
3-1. 이동한 칸이 같은 섬이면 continue로 해당칸의 이동확장을 가지치기해요.
3-2. 이동한 칸이 다른 섬이면 다리의 최소길이를 갱신하고 break합니다.
3-3. 둘에 해당 안하면 바다인거에요. 그 경우에는 이동횟수를 +1 해서 큐에 넣습니다.
4. while(!q.isEmpty()) 바깥에 v배열을 다시 초기화 하는데 이동루트를 path에 넣어놓고 v배열을 다시 복구하면 최적화가 가능해요.

## 10451 순열사이클(S3)
from과 to를 union해나가면서 사이클을 판단하는데, 다음 from을 이전 to로 변경해나가요. 그런데 마지막에 유니크한 root의 개수를 구하는 방법으로 풀면 그냥 from을 1부터 오름차순으로 진행해도 될것같아요. 그게 더 코드가 간단합니다.

1. 진출이 1개이기 때문에 int[]에 인덱스가 from, 값이 to로 저장합니다.
2. 1부터 n까지 for문을 돌아요. while문으로 to노드를 from으로 변경하며 union 합니다. 하다가 사이클이 발생하면 cnt를 증가시키고 while문 탈출합니다.
3.  for문의 j가 이미 방문되었다면 skip합니다.
