### PR TITLE
[한태희] 2146 다리만들기, 10451 순열사이클 #240109

### DIFF
--- a/한태희/0109/Main_bj_g3_2146_다리_만들기.py
+++ b/한태희/0109/Main_bj_g3_2146_다리_만들기.py
@@ -1,0 +1,57 @@
+import sys
+sys.setrecursionlimit(99999)
+
+dx = [-1, 1, 0, 0]
+dy = [0, 0, -1, 1]
+    
+def makeGroup(N, x, y, arr, groupName):
+    arr[y][x] = groupName
+    for k in range(4):
+        nx = x + dx[k]
+        ny = y + dy[k]
+        if 0<=nx<N and 0<=ny<N and arr[ny][nx] == 1:
+            makeGroup(N, nx, ny, arr, groupName)
+
+def slove_다리만들기(N, arr):
+
+    groupName = 2
+    for y in range(N):
+        for x in range(N):
+            if arr[y][x] == 1:
+                makeGroup(N, x, y, arr, groupName)
+                groupName +=1
+    
+    ret = 99999999999
+
+    for y1 in range(N):
+        for x1 in range(N):
+
+            if arr[y1][x1]==0:
+                continue
+
+            for y2 in range(N):
+                for x2 in range(N):
+
+                    if arr[y2][x2]==0:
+                        continue
+
+                    if y1 > y2:
+                        continue
+                    if y1 == y2 and x1 > x2:
+                        continue
+                    if arr[y1][x1] == arr[y2][x2]:
+                        continue
+
+                    length = abs(x1-x2) + abs(y1-y2) -1
+                    ret = min(ret, length)
+
+    return ret
+    
+if __name__ == "__main__":
+    N = int(input())
+    
+    ## arr 설명
+    ## 0: 바다 1: 이름이 없는 섬 2보다 큰 정수: 그 번호를 이름으로 가지는 섬
+    arr = [list(map(int, input().split())) for _ in range(N)]
+    
+    print(slove_다리만들기(N, arr))

--- a/한태희/0109/Main_bj_s3_10451_순열_사이클.py
+++ b/한태희/0109/Main_bj_s3_10451_순열_사이클.py
@@ -1,0 +1,33 @@
+def dfs(node, e, v):
+    v[node] = True
+    next = e[node]
+    if not v[next]:
+        dfs(next, e, v)
+
+def slove_순열사이클(N, arr):
+    e = {}
+    for i in range(len(arr)):
+        src = i + 1
+        dst = arr[i]
+        e[src] = dst
+    
+    v = []
+    for i in range(0, N+1):
+        v.append(False)
+
+    cnt = 0
+    for i in range(1, N+1):
+        if not v[i]:
+            dfs(i, e, v)
+            cnt +=1
+    
+    return cnt
+    
+if __name__ == "__main__":
+    T = int(input())
+    for tc in range(1, T+1):
+        N = int(input())
+        st = input()
+        arr = list(map(int, st.split()))
+
+        print(slove_순열사이클(N, arr))


### PR DESCRIPTION
파이썬으로 작성했습니다.

# 다리 만들기

이전에 풀었던 방법이 기억 나는 문제여서 금방 풀었습니다.

우선 각 섬의 땅 부분 중 붙어있는 부분끼리 2~K의 이름을 붙히는 방식으로 바다로 격리되어 있는 섬들을 구별합니다.
(2부터 시작인 이유는 기존 입력의 1: 땅 이라는 의미를 1: 아직 이름이 붙지 않은 땅 이라는 의미로 변형해서 사용했기 때문)

그 뒤, (x1, y1)과 (x2, y2) 두개의 점을 4중 for문으로 돌며, 만약 두 점이 서로 다른 섬 소속이라면 두 개 점 사이에 다리가 건설 가능한지 확인합니다. 이렇게 탐색한 다리의 길이 중 가장 짧은 길이가 정답입니다.

이런 단순 탐색으로 문제가 풀리는 이유는 아래와 같은 사실들 때문입니다.

1. 그룹 나누기의 작동 방식상 두개의 섬 사이엔 반드시 다리를 놓을 수 있는 바다 공간이 존재한다.
2. 만약, A B 두개의 땅 사이의 점을 검사중인데, A와 B 사이에 있는 섬 C가 최단거리를 놓을 수 없는 상황을 만든다면, A-B 최단거리보다 A-C나 B-C의 최단거리가 더 짧으므로 A-B는 정답이 아니게 된다.

---

# 순열 사이클

그래프 구조를 딕셔너리에 저장한 다음, dfs를 이용해 사이클의 개수를 구합니다. (그룹 구하기와 유사) dfs의 개시 횟수가 순환 그래프의 개수가 되는 문제입니다.

이 문제에서는 순환 그래프가 존재하지 않는 경우는 존재하지 않는다는 사실을 캐치하는 것이 문제를 빨리 푸는 지름길입니다.

만약 그래프가 1자로 늘어선 경우가 있다면 -> 어떤 한 점은 다음 점으로의 연결이 없는 것이므로 불가능.

만약 그래프가 1 -> 2 -> 3 -> 2 -> ... 같은 일부 노드만 순환하는 구조인 경우 -> 특정 도착점은 두 번 이상 등장함으로 순열의 개념에 위배된다. 따라서 존재하지 않는다.