### PR TITLE
[한태희] 2143 두 배열의 합,   9527 1의 개수 세기 #240116

### DIFF
--- a/한태희/0116/Main_bj_g2_9527_1의_개수_세기.java
+++ b/한태희/0116/Main_bj_g2_9527_1의_개수_세기.java
@@ -1,0 +1,53 @@
+import java.util.*;
+import java.io.*;
+import java.math.*;
+
+public class Main_bj_g2_9527_1의_개수_세기 {
+	static BigInteger two_pow[];
+
+	public static void main(String args[]) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		BigInteger A = new BigInteger(st.nextToken());
+		BigInteger B = new BigInteger(st.nextToken());
+
+		two_pow = new BigInteger[100];
+		two_pow[0] = new BigInteger("1");
+		for(int i=1;i<100;i++) {
+			two_pow[i] = two_pow[i-1].multiply(new BigInteger("2"));
+		}
+		
+		BigInteger fx_b = fx(B);
+		BigInteger fx_a = fx(A.subtract(BigInteger.ONE));
+
+		System.out.println(fx_b.subtract(fx_a));
+
+		br.close();
+	}
+
+	public static BigInteger fx(BigInteger num) {
+		num = num.add(BigInteger.ONE);
+
+		int bitLength = 0;
+		BigInteger temp = new BigInteger(num.toString());
+		while (temp.compareTo(BigInteger.ZERO) > 0) {
+			bitLength++;
+			temp = temp.divide(BigInteger.valueOf(2));
+		}
+		
+		BigInteger ret = new BigInteger("0");
+		for(int i=1;i<=bitLength;i++) {
+			BigInteger k = two_pow[i];
+			BigInteger kp = two_pow[i-1];
+			BigInteger a =	num.divide(k);
+			BigInteger b = num.mod(k);
+			ret = ret.add(a.multiply(kp));
+			if(b.subtract(kp).compareTo(BigInteger.ZERO) > 0){
+				ret = ret.add(b.subtract(kp));
+			}
+		}
+
+		return ret;
+	}
+
+}

--- a/한태희/0116/Main_bj_g3_2143_두_배열의_합.java
+++ b/한태희/0116/Main_bj_g3_2143_두_배열의_합.java
@@ -1,0 +1,59 @@
+import java.util.*;
+import java.io.*;
+
+public class Main_bj_g3_2143_두_배열의_합 {
+	static long T;
+	static int n, m;
+	static long[] A, B;
+
+	public static void main(String args[]) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		T = Long.parseLong(br.readLine());
+		
+		n = Integer.parseInt(br.readLine());
+		A = new long[n];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for(int i=0;i<n;i++){
+		    A[i] = Long.parseLong(st.nextToken());
+		}
+		
+		m = Integer.parseInt(br.readLine());
+		B = new long[m];
+		st = new StringTokenizer(br.readLine());
+		for(int i=0;i<m;i++){
+		    B[i] = Long.parseLong(st.nextToken());
+		}
+		
+		HashMap<Long, Long> AMap = new HashMap<>();
+		HashMap<Long, Long> BMap = new HashMap<>();
+		
+		for(int i=0;i<n;i++){
+		    long sum = 0;
+		    for(int j=i;j<n;j++){
+		        sum += A[j];
+		        AMap.put(sum, AMap.getOrDefault(sum, (long)0)+1);
+		    }
+		}
+
+		for(int i=0;i<m;i++){
+		    long sum = 0;
+		    for(int j=i;j<m;j++){
+		        sum += B[j];
+		        BMap.put(sum, BMap.getOrDefault(sum, (long)0)+1);
+		    }
+		}
+
+		long ans = 0;
+
+		for(long key : AMap.keySet()){
+		    if(BMap.containsKey(T-key)){
+		        ans += AMap.get(key) * BMap.get(T-key);
+		    }
+		}
+
+		System.out.println(ans);
+
+		br.close();
+	}
+
+}


### PR DESCRIPTION
# 두_배열의_합

두 배열에 대해서 각각 이중 for문으로 임의의 시작점과 끝점을 가질 때의 구간 합을 구하고, 결과를 {key:구간합 값, value:등장 빈도} 로 저장함.

이를 AMap과 BMap이라고 명명.
반환 값음 0이 초기값.

그 뒤에, AMap의 모든 요소를 순회하면서 A구간합 + B구간합 = T가 되는 경우를 검사함. 이런 경우에 두 등장 빈도를 곱하여 반환값에 더함.

이런 방식으로 문제에서 구해야 하는 모든 경우의 수를 구할 수 있음.

---

# 1의_개수_세기

이진수에서 1은
첫째 자리에서 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1...
둘째 자리에서 0 0 1 1 0 0 1 1 0 0 1 1 0 0 1 1...
셋째 자리에서 0 0 0 0 1 1 1 1 0 0 0 0 1 1 1 1...
넷째 자리에서 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1...

와 같이 2의 제곱에 기반한 패턴으로 등장한다. 자리수가 올라가더라도 0과 1은 1:1 비율로 등장하는 것을 알 수 있다.

이를 수식으로 나타내면,

임의의 이진수 숫자 X가 있을 때

a = (X+1) / (2^i) <나눗셈은 컴퓨터 정수의 나눗셈>

b = (X+1) % (2^i)

이라고 하면,

X의 i번째 자리수의 1의 등장 횟수는

몫 부분 = a * (2^(i-1))
나머지 부분
    (b-(2^(i-1))) >0 일 경우 : (b-(2^(i-1)))
    아닐 경우                : 0
이 된다.