### PR TITLE
[김준엽] - 두 배열의 합 && 1의 개수 세기

### DIFF
--- a/김준엽/20240116/1의개수세기.java
+++ b/김준엽/20240116/1의개수세기.java
@@ -1,0 +1,38 @@
+package a0105;
+
+import java.util.*;
+import java.io.*;
+public class Main {
+    static long start, end;
+    static long oneCount, ans;
+    static long[] dp = new long[64];
+    public static void main(String[] args) throws Exception{
+        System.setIn(new FileInputStream("/Users/kim-junyup/Downloads/ssafy_algo_backup/algo/input.txt"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        start = Long.parseLong(st.nextToken());
+        end = Long.parseLong(st.nextToken());
+        initDp();
+        ans = calc(end) - calc(start - 1);
+        System.out.println(ans);
+    }
+    static long calc(long n){
+        long count = n & 1;
+        int size = (int) (Math.log(n) / Math.log(2)); //bit size
+        //N - (1L << i) : 지정된 1이 반복 사용될 개수
+        // + 1 : 1000...
+        for(int i=size;i>0;i--) {
+            if((n & (1L<<i)) != 0L) {
+                count += dp[i-1] +(n - (1L<<i) + 1);
+                n -= (1L << i);	//비트 이동시키기
+            }
+        }
+        return count;
+    }
+    static void initDp(){
+        dp[0] = 1;
+        for (int i = 1; i < 64; i++) {
+            dp[i] = (dp[i-1] * 2) + (1L << i);
+        }
+    }
+}

--- a/김준엽/20240116/두배열의합.java
+++ b/김준엽/20240116/두배열의합.java
@@ -1,0 +1,77 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static long T,count;
+    static int N;
+    static int [] a,b;
+    static ArrayList<Long> aSum = new ArrayList<>();
+    static ArrayList<Long> bSum = new ArrayList<>();
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        T = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        a = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            a[i] = Integer.parseInt(st.nextToken());
+        }
+        //aSum
+        for (int i = 0; i < N; i++) {
+            long tmp = 0;
+            for (int j = i; j < N; j++) {
+                tmp += a[j];
+                aSum.add(tmp);
+            }
+        }
+
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        b = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            b[i] = Integer.parseInt(st.nextToken());
+        }
+        //bSum
+        for (int i = 0; i < N; i++) {
+            long tmp = 0;
+            for (int j = i; j < N; j++) {
+                tmp += b[j];
+                bSum.add(tmp);
+            }
+        }
+
+        Collections.sort(aSum);
+        Collections.sort(bSum);
+        int aIndex = 0;
+        int bIndex = bSum.size() - 1;
+        while(true){
+            long ans = aSum.get(aIndex) + bSum.get(bIndex);
+            if(ans < T) aIndex++;
+            else if(ans > T) bIndex--;
+            else{
+                long aNum = aSum.get(aIndex);
+                long bNum = bSum.get(bIndex);
+                long aCnt = 0, bCnt = 0;
+                while(aNum == aSum.get(aIndex)){
+                    aIndex++;
+                    aCnt++;
+                    if(aIndex == aSum.size()) break;
+                }
+                while(bNum == bSum.get(bIndex)){
+                    bIndex--;
+                    bCnt++;
+                    if(bIndex == -1) break;
+                }
+                count += aCnt * bCnt;
+            }
+            if(aIndex == aSum.size() || bIndex == -1) break;
+        }
+        System.out.println(count);
+    }
+}


### PR DESCRIPTION
앞으로는 수학 태그 달린 문제는 제외해야겠다..

# 두 배열의 합
- 처음에 부 배열이 `연속 되어 있다는` 조건을 놓쳐서 고생했다.
- 두 배열의 합을 구하는 것이기 때문에 각 A배열, B 배열의 부배열들의 합을 누적합을 이용하여 모든 경우의 수를 구해놓는다.
- 거기에 A 부배열의 합 + B 부배열의 합이 목표한 값이 같은지를 투 포인터를 활용한다. (aSum, bSum은 오름차순으로 정렬)
- aSum은 0부터 bSum은 오른쪽부터 투포인터 알고리즘을 활용하여 탐색한다.
`단 각 부배열의 합에는 중복 값이 있는 것을 체크해야한다.`

목표하는 값이 5일때 aSum에 2가 3개, bSum에 3이 4개 있다면 => 3 * 4 = 12개의 값이 나온다
또한 최종 값이 int 값을 벗어나는 경우의 수도 고려해야 정답이다...

# 1의 개수 세기
- 솔직히 해답을 봤다. 해답을 봐도 무슨소리인지 모르겠다.
## 처음 접근법
- 64비트를 넘어갈 수는 없으므로 각 비트의 상태를 나타내는 64개의 boolean 배열을 만든다. (true = 1 , false = 0)
- 시작 값의 2진수를 구한다 6 => 110 , 이 를 배열에는 0, 1, 1 로 거꾸로 넣는다. (1의 개수 2개)
- 이제 이를 0번 인덱스부터 1을 더해가며 다음 수를 만들어가며 목표한 값까지 반복문을 돌린다.
- 순서대로 1, 1, 1 => 0, 0, 0, 1, 그리고 이 과정에서 1의 개수는 +1 -1을 하며 누적하여 값을 구해준다

### 시간초과 났다.

아무리 최적화를 해도 범위가 너무 넓기 때문에 바로 시간초과가 났다. 블로그를 살펴보니 dp[n] = dp[n-1] * 2 + 2^n 이라는 점화식이 있다고 한다.
**단 n 은 비트의 수이다.**
- 그러면 14와 같은 애매한 수는 어떻게 계산을 해야할까?

[블로그1](https://cheon2308.tistory.com/entry/%EB%B0%B1%EC%A4%80-9527%EB%B2%88-%ED%8C%8C%EC%9D%B4%EC%8D%AC-1%EC%9D%98-%EA%B0%9C%EC%88%98-%EC%84%B8%EA%B8%B0)
[블로그2](https://tussle.tistory.com/1022)
그나마 이 두 블로그가 설명이 잘 되어 있다.

```
<메모>
1L << i // 1비트를 i칸 미는 것이므로 i만큼 제곱한다는 의미 
```

### 결론 : 문제 잘못골랐다. 앞으로 수학은 좀 줄이는 걸로 ^^;;
